### PR TITLE
chore: triangulate specific oidc_request by sub, clientID, and scopes

### DIFF
--- a/pkg/db/migrate/files/202006021731.sql
+++ b/pkg/db/migrate/files/202006021731.sql
@@ -28,12 +28,13 @@ CREATE TABLE oidc_request (
     end_user_id int NOT NULL,
 	relying_party_id int NOT NULL,
     scopes varchar(2000) NOT NULL,
+    scopes_hash varchar(128) NOT NULL,
 	pres_def text(65535),
     FOREIGN KEY (end_user_id) REFERENCES end_user(id),
     FOREIGN KEY (relying_party_id) REFERENCES relying_party(id)
 );
 
-CREATE INDEX oidc_requests_rpid_idx ON oidc_request(relying_party_id);
+CREATE INDEX oidc_requests_scopeshash_idx ON oidc_request(scopes_hash);
 
 -- +migrate Down
 DROP TABLE oidc_request;


### PR DESCRIPTION
closes #30 

depends on #31 

A specific OIDC request record is pulled from the DB by the EndUser target, the Relying Party that made it (clientID), and the scopes requested.

Field `scopes_hash` is transparently added to `oidc_request` with the hash of the array of scopes and indexed. This sets a max upper bound on the width of the datatype, allowing for efficient indexing.