### PR TITLE
feat: rp adapter creates oauth2 client at hydra

### DIFF
--- a/cmd/adapter-rest/startcmd/start.go
+++ b/cmd/adapter-rest/startcmd/start.go
@@ -363,11 +363,6 @@ func addRPHandlers(parameters *adapterRestParameters, ctx ariespai.CtxProvider, 
 		return err
 	}
 
-	_, err = initDB(parameters.dsn)
-	if err != nil {
-		return err
-	}
-
 	didClient, err := didexchange.New(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to initialized didexchange client : %w", err)
@@ -461,6 +456,7 @@ func newHydraClient(hydraURL *url.URL) *client.OryHydra {
 	)
 }
 
+//nolint:deadcode,unused
 func initDB(dsn string) (*sql.DB, error) {
 	const (
 		sleep      = 1 * time.Second

--- a/cmd/adapter-rest/startcmd/start_test.go
+++ b/cmd/adapter-rest/startcmd/start_test.go
@@ -72,12 +72,13 @@ var inputDescriptors = `{
 ]
 }`
 
-//nolint:gochecknoglobals
+//nolint:gochecknoglobals,unused
 var containerName = "edgeadapter_start_tests_" + strings.ReplaceAll(uuid.New().String(), "-", "")
 
 //nolint:gochecknoglobals
 var containerPort int
 
+//nolint:unused
 func startMySQL() error {
 	var err error
 
@@ -114,6 +115,7 @@ func startMySQL() error {
 	return nil
 }
 
+//nolint:unused
 func stopMySQL() error {
 	//nolint:gosec
 	err := exec.Command("docker", "stop", containerName).Run()
@@ -124,7 +126,8 @@ func stopMySQL() error {
 	return nil
 }
 
-func TestMain(m *testing.M) {
+//nolint:deadcode,unused
+func testMain(m *testing.M) {
 	err := startMySQL()
 	if err != nil {
 		panic(err)

--- a/pkg/restapi/rp/operation/models.go
+++ b/pkg/restapi/rp/operation/models.go
@@ -20,7 +20,12 @@ type GetPresentationRequestResponse struct {
 
 // CreateRPTenantRequest API request body to register an RP tenant.
 type CreateRPTenantRequest struct {
-	ClientID  string `json:"clientID"`
 	PublicDID string `json:"publicDID"`
 	Label     string `json:"label"`
+}
+
+// CreateRPTenantResponse API response body to register an RP tenant.
+type CreateRPTenantResponse struct {
+	ClientID     string
+	ClientSecret string
 }


### PR DESCRIPTION
This PR:

* enables the RP adapter to handle OAuth2 client registration at Hydra on behalf of the RP tenant, returning the ClientID and ClientSecret in the response (note: the ClientSecret is not stored by the RP Adapter)
* Removes test dependencies on MySQL in order to gain a few developer cycles. The relevant code was left unused.

closes #71 
closes #44

Signed-off-by: George Aristy <george.aristy@securekey.com>