### PR TITLE
refactor: #120 and #121

### DIFF
--- a/cmd/rp-adapter-vue/src/pages/Credentials.vue
+++ b/cmd/rp-adapter-vue/src/pages/Credentials.vue
@@ -24,9 +24,17 @@ SPDX-License-Identifier: Apache-2.0
             const credentialQuery = {
                 web: {
                     VerifiablePresentation: {
-                        query: {type: "CredentialsQuery"},
-                        presentationDefinition: this.presentationRequest.pd,
-                        did: this.presentationRequest.invitation,
+                        query: [
+                            {
+                                type: "presentationDefinitionQuery",
+                                presentationDefinitionQuery: this.presentationRequest.pd
+
+                            },
+                            {
+                                type: "DIDComm",
+                                invitation: this.presentationRequest.invitation
+                            }
+                        ]
                     }
                 }
             }

--- a/pkg/restapi/rp/operation/credentials.go
+++ b/pkg/restapi/rp/operation/credentials.go
@@ -15,116 +15,77 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/trustbloc/edge-adapter/pkg/internal/common/adapterutil"
+	"github.com/trustbloc/edge-adapter/pkg/presentationex"
 	"github.com/trustbloc/edge-adapter/pkg/vc"
 	"github.com/trustbloc/edge-adapter/pkg/vc/rp"
 )
 
-var errMalformedCredential = errors.New("malformed credential")
+var errInvalidCredential = errors.New("malformed credential")
 
-//nolint:unparam
-func getDIDDocAndUserConsentCredentials(vpBytes []byte) (*rp.DIDDocumentCredential, *vc.UserConsentCredential, error) {
-	creds, err := parseCredentials(vpBytes)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return parseDIDDocAndUserConsentCredentials(creds)
-}
-
-func parseCredentials(vpBytes []byte) ([2]*verifiable.Credential, error) {
-	const numCredentialsRequired = 2
-
+func parseWalletResponse(
+	definitions *presentationex.PresentationDefinitions, vpBytes []byte) (*vc.UserConsentCredential, error) {
 	vp, err := verifiable.ParsePresentation(vpBytes)
 	if err != nil {
-		return [2]*verifiable.Credential{},
-			errors.Wrapf(errMalformedCredential, fmt.Sprintf("error parsing a verifiable presentation : %s", err))
+		return nil, errors.Wrapf(
+			errInvalidCredential, fmt.Sprintf("error parsing a verifiable presentation : %s", err))
+	}
+
+	// TODO pass presentation definitions
+	err = evaluatePresentationSubmission(definitions, vp)
+	if err != nil {
+		return nil, errors.Wrapf(errInvalidCredential, "invalid presentation submission : %s", err)
 	}
 
 	rawCreds, err := vp.MarshalledCredentials()
 	if err != nil {
-		return [2]*verifiable.Credential{}, fmt.Errorf("failed to marshal credentials from vp : %w", err)
+		return nil, fmt.Errorf("failed to marshal credentials from vp : %w", err)
 	}
 
-	if len(rawCreds) != numCredentialsRequired {
-		return [2]*verifiable.Credential{},
-			errors.Wrapf(
-				errMalformedCredential,
-				fmt.Sprintf(
-					"received %d but expecting 2 verifiable credentials in the verifiable presentation",
-					len(rawCreds)))
-	}
+	var base *verifiable.Credential
 
-	var allCreds [2]*verifiable.Credential
+	for i := range rawCreds {
+		raw := rawCreds[i]
 
-	for i, raw := range rawCreds {
-		cred, err := verifiable.ParseCredential(raw)
-		if err != nil {
-			return [2]*verifiable.Credential{},
-				fmt.Errorf("failed to parse raw credential %s : %w", string(raw), err)
-		}
-
-		allCreds[i] = cred
-	}
-
-	return allCreds, nil
-}
-
-func parseDIDDocAndUserConsentCredentials(
-	creds [2]*verifiable.Credential) (*rp.DIDDocumentCredential, *vc.UserConsentCredential, error) {
-	var (
-		issuerDIDVC *rp.DIDDocumentCredential
-		consentVC   *vc.UserConsentCredential
-	)
-
-	for _, cred := range creds {
-		if adapterutil.StringsContains(rp.DIDDocumentCredentialType, cred.Types) {
-			if issuerDIDVC != nil {
-				return nil, nil, errors.Wrapf(errMalformedCredential, "duplicate did doc credential")
-			}
-
-			issuerDIDVC = &rp.DIDDocumentCredential{}
-
-			err := adapterutil.DecodeJSONMarshaller(cred, issuerDIDVC)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to decode did doc vc : %w", err)
-			}
-
-			continue
+		cred, parseErr := verifiable.ParseCredential(raw)
+		if parseErr != nil {
+			return nil, fmt.Errorf("failed to parse raw credential %s : %w", string(raw), parseErr)
 		}
 
 		if adapterutil.StringsContains(vc.UserConsentCredentialType, cred.Types) {
-			if consentVC != nil {
-				return nil, nil, errors.Wrapf(errMalformedCredential, "duplicate user consent credential")
-			}
-
-			consentVC = &vc.UserConsentCredential{}
-
-			err := adapterutil.DecodeJSONMarshaller(cred, consentVC)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to decode user consent credential : %w", err)
-			}
-
-			continue
+			base = cred
+			break
 		}
 
-		return nil, nil, errors.Wrapf(errMalformedCredential, "unrecognized vc types %+v", cred.Types)
+		logger.Warnf("ignoring credential with unrecognized types: %+v", cred.Types)
 	}
 
-	return issuerDIDVC, consentVC, nil
+	if base == nil {
+		return nil, errors.Wrapf(
+			errInvalidCredential, "no suitable credential of type %s found", vc.UserConsentCredentialType)
+	}
+
+	consentVC := &vc.UserConsentCredential{Base: base}
+
+	err = adapterutil.DecodeJSONMarshaller(base, consentVC)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode user consent credential : %w", err)
+	}
+
+	return consentVC, nil
 }
 
-func getPresentationSubmissionVP(
-	attachmentFormatID string, presentation *presentproof.Presentation) (*rp.PresentationSubmissionPresentation, error) {
+func parseIssuerResponse(definitions *presentationex.PresentationDefinitions,
+	presentation *presentproof.Presentation) (*rp.PresentationSubmissionPresentation, error) {
 	var attachmentID string
 
 	for _, f := range presentation.Formats {
-		if f.Format == attachmentFormatID {
+		if f.Format == presentationSubmissionFormat {
 			attachmentID = f.AttachID
 		}
 	}
 
 	if attachmentID == "" {
-		return nil, fmt.Errorf("no attachment found for given format %s", attachmentFormatID)
+		return nil, fmt.Errorf("no attachment found with expected format %s", presentationSubmissionFormat)
 	}
 
 	a := getAttachmentByID(attachmentID, presentation.PresentationsAttach)
@@ -140,7 +101,12 @@ func getPresentationSubmissionVP(
 	vp, err := verifiable.ParsePresentation(vpBytes)
 	if err != nil {
 		return nil,
-			errors.Wrapf(errMalformedCredential, fmt.Sprintf("failed to parse a verifiable presentation : %s", err))
+			errors.Wrapf(errInvalidCredential, fmt.Sprintf("failed to parse a verifiable presentation : %s", err))
+	}
+
+	err = evaluatePresentationSubmission(definitions, vp)
+	if err != nil {
+		return nil, errors.Wrapf(errInvalidCredential, "invalid presentation submission : %s", err)
 	}
 
 	presentationSubmissionVP := &rp.PresentationSubmissionPresentation{
@@ -153,6 +119,20 @@ func getPresentationSubmissionVP(
 	}
 
 	return presentationSubmissionVP, nil
+}
+
+// TODO validate presentation_submission against presentation_definitions
+//  https://github.com/trustbloc/edge-adapter/issues/108
+func evaluatePresentationSubmission(_ *presentationex.PresentationDefinitions, vp *verifiable.Presentation) error {
+	if !adapterutil.StringsContains(rp.PresentationSubmissionPresentationType, vp.Type) {
+		return errors.Wrapf(errInvalidCredential, "unexpected verifiable presentation type: %+v", vp.Type)
+	}
+
+	submission := &rp.PresentationSubmissionPresentation{
+		Base: vp,
+	}
+
+	return adapterutil.DecodeJSONMarshaller(vp, submission)
 }
 
 func getAttachmentByID(id string, attachments []decorator.Attachment) *decorator.Attachment {

--- a/pkg/vc/models.go
+++ b/pkg/vc/models.go
@@ -21,8 +21,16 @@ type UserConsentCredential struct {
 
 // UserConsentCredentialSubject is the custom credentialSubject of a UserConsentCredential.
 type UserConsentCredentialSubject struct {
+	ID        string       `json:"id"`
+	RPDID     *DIDDocument `json:"rpDID"`
+	IssuerDID *DIDDocument `json:"issuerDID"`
+	PresDef   string       `json:"presDef"`
+}
+
+// DIDDocument is how a DID document is transported over the wire.
+// The ID is separate from the contents (DocB64URL) because of the self-certifying properties of some
+// DID methods (eg. did:peer and did:key) where the ID is derived from the rest of the contents of the document.
+type DIDDocument struct {
 	ID        string `json:"id"`
-	RPDID     string `json:"rpDID"`
-	IssuerDID string `json:"issuerDID"`
-	PresDef   string `json:"presDef"`
+	DocB64URL string `json:"docB64Url"`
 }

--- a/pkg/vc/rp/models.go
+++ b/pkg/vc/rp/models.go
@@ -13,21 +13,9 @@ import (
 )
 
 const (
-	// DIDDocumentCredentialType is the DIDDocumentCredential's JSON-LD type.
-	DIDDocumentCredentialType = "DIDDocumentCredential"
+	// PresentationSubmissionPresentationType is the PresentationSubmissionPresentation's JSON-LD type.
+	PresentationSubmissionPresentationType = "PresentationSubmission"
 )
-
-// DIDDocumentCredential is a VC that contains a DID document.
-type DIDDocumentCredential struct {
-	Base    *verifiable.Credential   `json:"-"`
-	Subject *DIDDocCredentialSubject `json:"credentialSubject"`
-}
-
-// DIDDocCredentialSubject is the custom credentialSubject of a DIDDocumentCredential.
-type DIDDocCredentialSubject struct {
-	ID     string `json:"id"`
-	DIDDoc string `json:"didDoc"`
-}
 
 // PresentationSubmissionPresentation is the PresentationSubmission VerifiablePresentation.
 // https://identity.foundation/presentation-exchange/#presentation-submission.


### PR DESCRIPTION
closes #120 
closes #121 

* #120: rp adapter:
  * embed issuer's and rp's did docs in the consent VC
  * chapiResponseHandler now expects a VP (presentation_submission)
    with a single VC (the user's consent VC)
* #121: rp adapter: refactor CHAPI request

<details><summary>Example of a CHAPI request:</summary>
<p>

```javascript
{
    web: {
        VerifiablePresentation: {
            query: [
                {
                    type: "presentationDefinitionQuery",
                    presentationDefinitionQuery: {
                        "input_descriptors": [
                          {
                            "id": "banking_input_1",
                            "group": ["scope1"],
                            "schema": {
                              "uri": "https://bank-standards.com/customer.json",
                              "name": "Bank Account Information",
                              "purpose": "We need your bank and account information."
                            }
                          }
                        ]
                    }
                },
                {
                    type: "DIDComm",
                    invitation: {
                      "@id": "123456",
                      "@type": "https://didcomm.org/didexchange/1.0/invitation",
                      "label": "RP's public label",
                      "did": "did:trustbloc:testnet.trustbloc.local:1234567"
                    }
                }
            ]
        }
    }
}
```

</p>
</details>

<details><summary>Example request to issuer:</summary>
<p>

```jsonc
{
  "@id": "123456",
  "@type": "https://didcomm.org/present-proof/2.0/request-presentation",
  "formats": [
    {
      "attach_id": "123",
      "format": "w3c/did-core@v1.0-draft",
    },
    {
      "attach_id": "456",
      "format": "dif/presentation_definition@0.0.1",   
    }
  ],
  "request_presentations~attach": [
    {
      "@id": "123",
      "mime-type": "text/plain",
      "data": {
        "base64": "base64-encode(userPeerDID.ID)"
      }
    },
    {
      "@id": "456",
      "mime-type": "application/json",
      "data": {
        "json": {
          "input_descriptors": [
            {
              "id": "banking_input_1",
              "group": ["scope1"],
              "schema": {
                "uri": "https://bank-standards.com/customer.json",
                "name": "Bank Account Information",
                "purpose": "We need your bank and account information."
              }
            }
          ]
        }
      }   
    }
  ]
}
```
</p>
</details>

<details><summary>Example Issuer response:</summary>
<p>

```jsonc
{
  "@id": "123456",
  "@type": "https://didcomm.org/present-proof/2.0/presentation",
  "formats": [{
    "attach_id": "123456",
    "format": "dif/presentation_submission@0.0.1"
  }],
  "presentations~attach": [{
    "@id": "123456", // same as attach_id above
    "mime-type": "application/ld+json",
    "data": {
      "json": {
         "@context": [
             "https://www.w3.org/2018/credentials/v1",
             "https://trustbloc.github.io/context/vp/presentation-exchange-submission-v1.jsonld"
         ],
         "type": [
             "VerifiablePresentation",
             "PresentationSubmission"
         ],
         "presentation_submission": {
             "descriptor_map": [{
                 "id": "banking_input_1",
                 "path": "$.verifiableCredential.[0]"
             }]
         },
         "verifiableCredential": [{
             "@context": [
                 "https://www.w3.org/2018/credentials/v1",
                 "https://trustbloc.github.io/context/vc/examples-v1.jsonld"
             ],
             "type": [
                 "VerifiableCredential",
                 "CreditCardStatementCredential"
             ],
             "id": "http://example.gov/credentials/ff98f978-588f-4eb0-b17b-60c18e1dac2c",
             "issuanceDate": "2020-03-16T22:37:26.544Z",
             "issuer": {
                 "id": "did:peer:issuer"
             },
             "credentialSubject": {
                 "id": "did:peer:user",
                 "stmt": {
                     "description": "June 2020 Credit Card Statement",
                     "url": "http://acmebank.com/invoice.pdf",
                     "accountId": "xxxx-xxxx-xxxx-1234",
                     "customer": {
                         "@type": "Person",
                         "name": "Jane Doe"
                     },
                     "paymentDueDate": "2020-06-30T12:00:00",
                     "minimumPaymentDue": {
                         "@type": "PriceSpecification",
                         "price": 15.00,
                         "priceCurrency": "CAD"
                     },
                     "totalPaymentDue": {
                         "@type": "PriceSpecification",
                         "price": 200.00,
                         "priceCurrency": "CAD"
                     },
                     "billingPeriod": "P30D",
                     "paymentStatus": "http://schema.org/PaymentDue"			
                 }
             }
         }]
      }
    }
  }]
}
```
</p>
</details>

Signed-off-by: George Aristy <george.aristy@securekey.com>