### PR TITLE
refactor: #137 rp adapter: use explicit didcomm invitations

### DIFF
--- a/pkg/internal/mock/connection/connection_lookup.go
+++ b/pkg/internal/mock/connection/connection_lookup.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
 )
 
-// ConnectionsLookup mock connections lookup.
-type ConnectionsLookup struct {
+// MockConnectionsLookup mock connections lookup.
+type MockConnectionsLookup struct {
 	ConnIDByDIDs    string
 	ConnIDByDIDsErr error
 	ConnRecord      *connection.Record
@@ -21,7 +21,7 @@ type ConnectionsLookup struct {
 }
 
 // GetConnectionIDByDIDs returns the connection id based on dids (my or their did) metadata.
-func (c *ConnectionsLookup) GetConnectionIDByDIDs(myDID, theirDID string) (string, error) {
+func (c *MockConnectionsLookup) GetConnectionIDByDIDs(myDID, theirDID string) (string, error) {
 	switch {
 	case c.ConnIDByDIDsErr != nil:
 		return "", c.ConnIDByDIDsErr
@@ -33,7 +33,7 @@ func (c *ConnectionsLookup) GetConnectionIDByDIDs(myDID, theirDID string) (strin
 }
 
 // GetConnectionRecord returns the connection record based on the connection ID.
-func (c *ConnectionsLookup) GetConnectionRecord(id string) (*connection.Record, error) {
+func (c *MockConnectionsLookup) GetConnectionRecord(id string) (*connection.Record, error) {
 	switch {
 	case c.ConnRecordErr != nil:
 		return nil, c.ConnRecordErr

--- a/pkg/internal/mock/didexchange/client.go
+++ b/pkg/internal/mock/didexchange/client.go
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didexchange
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+)
+
+// MockClient is a mock didexchange.MockClient used in tests.
+type MockClient struct {
+	ActionEventFunc      func(chan<- service.DIDCommAction) error
+	MsgEventFunc         func(chan<- service.StateMsg) error
+	CreateInvWithDIDFunc func(string, string) (*didexchange.Invitation, error)
+	CreateInvFunc        func(string) (*didexchange.Invitation, error)
+}
+
+// RegisterActionEvent registers the action event channel.
+func (s *MockClient) RegisterActionEvent(actions chan<- service.DIDCommAction) error {
+	if s.ActionEventFunc != nil {
+		return s.ActionEventFunc(actions)
+	}
+
+	return nil
+}
+
+// RegisterMsgEvent registers the message event channel.
+func (s *MockClient) RegisterMsgEvent(msgs chan<- service.StateMsg) error {
+	if s.MsgEventFunc != nil {
+		return s.MsgEventFunc(msgs)
+	}
+
+	return nil
+}
+
+// CreateInvitationWithDID creates an implicit invitation with the given DID.
+func (s *MockClient) CreateInvitationWithDID(label, didID string) (*didexchange.Invitation, error) {
+	return s.CreateInvWithDIDFunc(label, didID)
+}
+
+// CreateInvitation creates an explicit invitation.
+func (s *MockClient) CreateInvitation(label string) (*didexchange.Invitation, error) {
+	return s.CreateInvFunc(label)
+}

--- a/pkg/internal/mock/presentproof/client.go
+++ b/pkg/internal/mock/presentproof/client.go
@@ -11,14 +11,14 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 )
 
-// Client is a mock presentproof.Client used in tests.
-type Client struct {
+// MockClient is a mock presentproof.MockClient used in tests.
+type MockClient struct {
 	RegisterActionFunc      func(chan<- service.DIDCommAction) error
 	RequestPresentationFunc func(*presentproof.RequestPresentation, string, string) (string, error)
 }
 
 // RegisterActionEvent registers the action event channel.
-func (s *Client) RegisterActionEvent(ch chan<- service.DIDCommAction) error {
+func (s *MockClient) RegisterActionEvent(ch chan<- service.DIDCommAction) error {
 	if s.RegisterActionFunc != nil {
 		return s.RegisterActionFunc(ch)
 	}
@@ -27,22 +27,22 @@ func (s *Client) RegisterActionEvent(ch chan<- service.DIDCommAction) error {
 }
 
 // UnregisterActionEvent unregisters the action channnel.
-func (s *Client) UnregisterActionEvent(ch chan<- service.DIDCommAction) error {
+func (s *MockClient) UnregisterActionEvent(ch chan<- service.DIDCommAction) error {
 	panic("implement me")
 }
 
 // RegisterMsgEvent registers the message event channel.
-func (s *Client) RegisterMsgEvent(ch chan<- service.StateMsg) error {
+func (s *MockClient) RegisterMsgEvent(ch chan<- service.StateMsg) error {
 	panic("implement me")
 }
 
 // UnregisterMsgEvent unregisters the msg event channel.
-func (s *Client) UnregisterMsgEvent(ch chan<- service.StateMsg) error {
+func (s *MockClient) UnregisterMsgEvent(ch chan<- service.StateMsg) error {
 	panic("implement me")
 }
 
 // SendRequestPresentation simulates the action of sending a request presentation to theirDID.
-func (s *Client) SendRequestPresentation(
+func (s *MockClient) SendRequestPresentation(
 	presentation *presentproof.RequestPresentation, myDID, theirDID string) (string, error) {
 	return s.RequestPresentationFunc(presentation, myDID, theirDID)
 }

--- a/pkg/restapi/issuer/operation/operations_test.go
+++ b/pkg/restapi/issuer/operation/operations_test.go
@@ -387,7 +387,7 @@ func TestValidateWalletResponse(t *testing.T) {
 	txn, err := c.getTxn(txnID)
 	require.NoError(t, err)
 
-	c.connectionLookup = &mockconn.ConnectionsLookup{
+	c.connectionLookup = &mockconn.MockConnectionsLookup{
 		ConnIDByDIDs: connID,
 		ConnRecord: &connection.Record{
 			ConnectionID:   connID,
@@ -468,7 +468,7 @@ func TestValidateWalletResponse(t *testing.T) {
 		txn, err = c.getTxn(txnID)
 		require.NoError(t, err)
 
-		c.connectionLookup = &mockconn.ConnectionsLookup{
+		c.connectionLookup = &mockconn.MockConnectionsLookup{
 			ConnIDByDIDs: connID,
 			ConnRecord: &connection.Record{
 				State:          didExCompletedState,
@@ -493,7 +493,7 @@ func TestValidateWalletResponse(t *testing.T) {
 
 	t.Run("test validate response - validate connection errors", func(t *testing.T) {
 		// inviterDID and inviteeDID combo not found
-		c.connectionLookup = &mockconn.ConnectionsLookup{
+		c.connectionLookup = &mockconn.MockConnectionsLookup{
 			ConnIDByDIDsErr: errors.New("connID not found"),
 		}
 
@@ -511,7 +511,7 @@ func TestValidateWalletResponse(t *testing.T) {
 		require.Contains(t, rr.Body.String(), "connection using DIDs not found")
 
 		// connection not found
-		c.connectionLookup = &mockconn.ConnectionsLookup{
+		c.connectionLookup = &mockconn.MockConnectionsLookup{
 			ConnIDByDIDs:  connID,
 			ConnRecordErr: errors.New("connection not found"),
 		}
@@ -523,7 +523,7 @@ func TestValidateWalletResponse(t *testing.T) {
 		require.Contains(t, rr.Body.String(), "connection using id not found")
 
 		// connection state not completed
-		c.connectionLookup = &mockconn.ConnectionsLookup{
+		c.connectionLookup = &mockconn.MockConnectionsLookup{
 			ConnIDByDIDs: connID,
 			ConnRecord: &connection.Record{
 				ParentThreadID: txn.DIDCommInvitation.ID,
@@ -537,7 +537,7 @@ func TestValidateWalletResponse(t *testing.T) {
 		require.Contains(t, rr.Body.String(), "connection state is not complete")
 
 		// threadID not found
-		c.connectionLookup = &mockconn.ConnectionsLookup{
+		c.connectionLookup = &mockconn.MockConnectionsLookup{
 			ConnIDByDIDs: connID,
 			ConnRecord: &connection.Record{
 				ParentThreadID: txn.DIDCommInvitation.ID,
@@ -560,7 +560,7 @@ func TestValidateWalletResponse(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		ops.connectionLookup = &mockconn.ConnectionsLookup{
+		ops.connectionLookup = &mockconn.MockConnectionsLookup{
 			ConnIDByDIDs: connID,
 			ConnRecord: &connection.Record{
 				ConnectionID:   connID,

--- a/pkg/restapi/rp/controller_test.go
+++ b/pkg/restapi/rp/controller_test.go
@@ -8,13 +8,12 @@ package rp
 import (
 	"testing"
 
-	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	ariesmockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	ariesstorage "github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/edge-core/pkg/storage/memstore"
 
+	"github.com/trustbloc/edge-adapter/pkg/internal/mock/didexchange"
 	mockpresentproof "github.com/trustbloc/edge-adapter/pkg/internal/mock/presentproof"
 	"github.com/trustbloc/edge-adapter/pkg/restapi/rp/operation"
 )
@@ -22,10 +21,10 @@ import (
 func TestController_New(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		controller, err := New(&operation.Config{
-			DIDExchClient:        &stubDIDClient{},
+			DIDExchClient:        &didexchange.MockClient{},
 			Store:                memstore.NewProvider(),
 			AriesStorageProvider: &mockAriesStorageProvider{},
-			PresentProofClient:   &mockpresentproof.Client{},
+			PresentProofClient:   &mockpresentproof.MockClient{},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, controller)
@@ -33,21 +32,6 @@ func TestController_New(t *testing.T) {
 
 		require.Equal(t, 7, len(ops))
 	})
-}
-
-type stubDIDClient struct {
-}
-
-func (s *stubDIDClient) RegisterActionEvent(chan<- service.DIDCommAction) error {
-	return nil
-}
-
-func (s *stubDIDClient) RegisterMsgEvent(chan<- service.StateMsg) error {
-	return nil
-}
-
-func (s *stubDIDClient) CreateInvitationWithDID(string, string) (*didexchange.Invitation, error) {
-	return nil, nil
 }
 
 type mockAriesStorageProvider struct {

--- a/pkg/restapi/rp/operation/models.go
+++ b/pkg/restapi/rp/operation/models.go
@@ -22,7 +22,8 @@ type GetPresentationRequestResponse struct {
 
 // CreateRPTenantRequest API request body to register an RP tenant.
 type CreateRPTenantRequest struct {
-	Label string `json:"label"`
+	Label    string `json:"label"`
+	Callback string `json:"callback"`
 }
 
 // CreateRPTenantResponse API response body to register an RP tenant.

--- a/test/bdd/features/rp_e2e.feature
+++ b/test/bdd/features/rp_e2e.feature
@@ -8,6 +8,6 @@
 @rp_adapter
 Feature: RP Adapter
   Scenario: Register relying party
-    When a request is sent to create an RP tenant with label "test-tenant"
+    When a request is sent to create an RP tenant with label "test-tenant" and callback "http://todo.com"
     Then the trustbloc DID of the tenant with label "test-tenant" is resolvable
     And the client ID of the tenant with label "test-tenant" is registered at hydra

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -8,6 +8,7 @@ go 1.14
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cucumber/godog v0.9.0
 	github.com/fsouza/go-dockerclient v1.6.5
 	github.com/google/uuid v1.1.1


### PR DESCRIPTION
closes #137 

This PR includes fixes 2 and 3 as well:

1. makes the RP adapter use explicit didexchange invitations instead of implicit ones using the RP tenant's public DID
2. fix: missing callback url when registering rp tenants
3. fix: user subject is empty when the user has not "logged in" yet with the adapter
4. moves the mock didexchange client to its own package

Signed-off-by: George Aristy <george.aristy@securekey.com>