### PR TITLE
fix: #187 rp-adapter: various fixes

### DIFF
--- a/cmd/adapter-rest/startcmd/start_test.go
+++ b/cmd/adapter-rest/startcmd/start_test.go
@@ -149,6 +149,10 @@ func (s *mockServer) ListenAndServe(host string, handler http.Handler) error {
 	return nil
 }
 
+func (s *mockServer) ListenAndServeTLS(host, certPath, keyPath string, handler http.Handler) error {
+	return nil
+}
+
 func TestListenAndServe(t *testing.T) {
 	var w HTTPServer
 	err := w.ListenAndServe("wronghost", nil)

--- a/cmd/rp-adapter-vue/src/pages/Credentials.vue
+++ b/cmd/rp-adapter-vue/src/pages/Credentials.vue
@@ -38,6 +38,7 @@ SPDX-License-Identifier: Apache-2.0
                     }
                 }
             }
+            console.log("rp-adapter: chapi request: " + JSON.stringify(credentialQuery, undefined, 4))
             const webCredential = await navigator.credentials.get(credentialQuery)
             if (!webCredential) {
                 console.error("no webcredential received from wallet!")
@@ -71,9 +72,12 @@ SPDX-License-Identifier: Apache-2.0
                 )
             },
             async validatePresentation(presentation) {
+                if (!presentation.data) {
+                    throw new Error("user did not submit a proper web credential")
+                }
                 const request = {
                     invID: this.presentationRequest.invitation["@id"],
-                    vp: presentation
+                    vp: presentation.data
                 }
                 return this.$http.post(`/presentations/handleResponse`, request).then(
                     resp => {

--- a/pkg/restapi/rp/operation/credentials.go
+++ b/pkg/restapi/rp/operation/credentials.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/presentproof"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	"github.com/pkg/errors"
 
 	"github.com/trustbloc/edge-adapter/pkg/internal/common/adapterutil"
@@ -21,7 +22,7 @@ import (
 
 var errInvalidCredential = errors.New("malformed credential")
 
-func parseWalletResponse(definitions *presentationex.PresentationDefinitions,
+func parseWalletResponse(definitions *presentationex.PresentationDefinitions, vdriReg vdriapi.Registry,
 	vpBytes []byte) (*vc.ConsentCredential, *verifiable.Credential, error) {
 	vp, err := verifiable.ParsePresentation(vpBytes)
 	if err != nil {
@@ -44,7 +45,10 @@ func parseWalletResponse(definitions *presentationex.PresentationDefinitions,
 	for i := range rawCreds {
 		raw := rawCreds[i]
 
-		cred, parseErr := verifiable.ParseCredential(raw)
+		cred, parseErr := verifiable.ParseCredential(
+			raw,
+			verifiable.WithPublicKeyFetcher(verifiable.NewDIDKeyResolver(vdriReg).PublicKeyFetcher()),
+		)
 		if parseErr != nil {
 			return nil, nil, fmt.Errorf(
 				"%w : failed to parse raw credential %s : %s",

--- a/pkg/restapi/rp/operation/credentials_test.go
+++ b/pkg/restapi/rp/operation/credentials_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	mockvdri "github.com/hyperledger/aries-framework-go/pkg/mock/vdri"
+
 	"github.com/google/uuid"
 	"github.com/hyperledger/aries-framework-go/pkg/client/presentproof"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
@@ -41,7 +43,7 @@ func TestParseWalletResponse(t *testing.T) {
 		issuerDID := newPeerDID(t)
 		origConsentVC := newUserConsentVC(t, userDID.ID, rpDID, issuerDID)
 		vp := newPresentationSubmissionVP(t, origConsentVC)
-		customConsentVC, resultOrigConsentVC, err := parseWalletResponse(nil, marshalVP(t, vp))
+		customConsentVC, resultOrigConsentVC, err := parseWalletResponse(nil, &mockvdri.MockVDRIRegistry{}, marshalVP(t, vp))
 		require.NoError(t, err)
 		require.Equal(t, origConsentVC.Subject, resultOrigConsentVC.Subject)
 		require.NotNil(t, customConsentVC.Subject)
@@ -62,7 +64,7 @@ func TestParseWalletResponse(t *testing.T) {
 			newUniversityDegreeVC(t), // ignored
 			newUserConsentVC(t, newPeerDID(t).ID, newPeerDID(t), newPeerDID(t)),
 		)
-		customConsentVC, origConsentVC, err := parseWalletResponse(nil, marshalVP(t, vp))
+		customConsentVC, origConsentVC, err := parseWalletResponse(nil, &mockvdri.MockVDRIRegistry{}, marshalVP(t, vp))
 		require.NoError(t, err)
 		require.NotNil(t, customConsentVC)
 		require.NotNil(t, origConsentVC)
@@ -72,25 +74,25 @@ func TestParseWalletResponse(t *testing.T) {
 		consentVC := newUserConsentVC(t, newPeerDID(t).ID, newPeerDID(t), newPeerDID(t))
 		vp, err := consentVC.Presentation()
 		require.NoError(t, err)
-		_, _, err = parseWalletResponse(nil, marshalVP(t, vp))
+		_, _, err = parseWalletResponse(nil, &mockvdri.MockVDRIRegistry{}, marshalVP(t, vp))
 		require.True(t, errors.Is(err, errInvalidCredential))
 	})
 
 	t.Run("errInvalidCredential on no credentials", func(t *testing.T) {
 		vp := newPresentationSubmissionVP(t)
-		_, _, err := parseWalletResponse(nil, marshalVP(t, vp))
+		_, _, err := parseWalletResponse(nil, &mockvdri.MockVDRIRegistry{}, marshalVP(t, vp))
 		require.True(t, errors.Is(err, errInvalidCredential))
 	})
 
 	t.Run("errInvalidCredential if issuer's did doc is missing", func(t *testing.T) {
 		vp := newPresentationSubmissionVP(t, newUserConsentVCMissingIssuerDIDDoc(t, newPeerDID(t).ID, newPeerDID(t)))
-		_, _, err := parseWalletResponse(nil, marshalVP(t, vp))
+		_, _, err := parseWalletResponse(nil, &mockvdri.MockVDRIRegistry{}, marshalVP(t, vp))
 		require.True(t, errors.Is(err, errInvalidCredential))
 	})
 
 	t.Run("errInvalidCredential if vc cannot be parsed", func(t *testing.T) {
 		vp := newPresentationSubmissionVPUnparseableVC(t)
-		_, _, err := parseWalletResponse(nil, marshalVP(t, vp))
+		_, _, err := parseWalletResponse(nil, &mockvdri.MockVDRIRegistry{}, marshalVP(t, vp))
 		require.True(t, errors.Is(err, errInvalidCredential))
 	})
 }

--- a/pkg/restapi/rp/operation/operations_test.go
+++ b/pkg/restapi/rp/operation/operations_test.go
@@ -2203,6 +2203,21 @@ func TestCreateRPTenant(t *testing.T) {
 	})
 }
 
+func TestRemoveOIDCScope(t *testing.T) {
+	t.Run("removes oidc scope", func(t *testing.T) {
+		scopes := []string{oidc.ScopeOpenID, uuid.New().String(), uuid.New().String(), uuid.New().String()}
+		result := removeOIDCScope(scopes)
+		require.NotContains(t, result, oidc.ScopeOpenID)
+		for _, scope := range scopes {
+			if scope == oidc.ScopeOpenID {
+				continue
+			}
+
+			require.Contains(t, result, scope)
+		}
+	})
+}
+
 type stubWriter struct {
 }
 

--- a/test/bdd/features/healthcheck_api.feature
+++ b/test/bdd/features/healthcheck_api.feature
@@ -13,5 +13,5 @@ Feature: health check
     Then the JSON path "<respKey>" of the response equals "<respKeyVal>"
     Examples:
       | url                                             | respKey       | respKeyVal                                      |
-      | http://localhost:8070/healthcheck               | status        | success                                         |
+      | https://localhost:8070/healthcheck               | status        | success                                         |
       | http://localhost:9070/healthcheck               | status        | success                                         |

--- a/test/bdd/fixtures/adapter-rest/docker-compose.yml
+++ b/test/bdd/fixtures/adapter-rest/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - ADAPTER_REST_HOST_URL=0.0.0.0:9070
       - ADAPTER_REST_TLS_CACERTS=/etc/tls/ec-cacert.pem
       - ADAPTER_REST_TLS_SYSTEMCERTPOOL=true
+      - ADAPTER_REST_TLS_SERVE_CERT=/etc/tls/ec-pubCert.pem
+      - ADAPTER_REST_TLS_SERVE_KEY=/etc/tls/ec-key.pem
       - ADAPTER_REST_DIDCOMM_INBOUND_HOST=0.0.0.0:9071
       - ADAPTER_REST_DIDCOMM_INBOUND_HOST_EXTERNAL=http://issuer.adapter.rest.example.com:9071
       - ADAPTER_REST_TRUSTBLOC_DOMAIN=${BLOC_DOMAIN}
@@ -35,6 +37,8 @@ services:
       - ADAPTER_REST_HOST_URL=0.0.0.0:8070
       - ADAPTER_REST_TLS_CACERTS=/etc/tls/ec-cacert.pem
       - ADAPTER_REST_TLS_SYSTEMCERTPOOL=true
+      - ADAPTER_REST_TLS_SERVE_CERT=/etc/tls/ec-pubCert.pem
+      - ADAPTER_REST_TLS_SERVE_KEY=/etc/tls/ec-key.pem
       - ADAPTER_REST_DSN=mysql://root:secret@mysql:3306/mysql
       - ADAPTER_REST_OP_URL=http://PUT-SOMETHING-HERE.com
       - ADAPTER_REST_PRESENTATION_DEFINITIONS_FILE=/etc/testdata/presentationdefinitions.json
@@ -67,8 +71,8 @@ services:
     environment:
       - DSN=mysql://root:secret@tcp(mysql:3306)/mysql?max_conns=20&max_idle_conns=4
       - URLS_SELF_ISSUER=https://localhost:4444
-      - URLS_CONSENT=http://localhost:8070/consent
-      - URLS_LOGIN=http://localhost:8070/login
+      - URLS_CONSENT=https://localhost:8070/consent
+      - URLS_LOGIN=https://localhost:8070/login
       - SECRETS_SYSTEM=testSecretsSystem
       - OIDC_SUBJECT_TYPES_SUPPORTED=public
       - OIDC_SUBJECT_TYPE_PAIRWISE_SALT=testSecretsSystem


### PR DESCRIPTION
fixes #187

- remove openid scope from the input to the presentations-definitions provider
- fix SSL_ERROR_RX_RECORD_TOO_LONG on firefox (on chrome the error is different) by serving HTTPS
- incorrect wallet data sent to the backend for evaluation
- configure publickeyfetcher when parsing verifiable credential from wallet

Signed-off-by: George Aristy <george.aristy@securekey.com>