### PR TITLE
refactor: rpadapter: #29 use transient storage

### DIFF
--- a/pkg/restapi/rp/controller_test.go
+++ b/pkg/restapi/rp/controller_test.go
@@ -22,8 +22,11 @@ import (
 func TestController_New(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		controller, err := New(&operation.Config{
-			DIDExchClient:        &didexchange.MockClient{},
-			Store:                memstore.NewProvider(),
+			DIDExchClient: &didexchange.MockClient{},
+			Storage: &operation.Storage{
+				Persistent: memstore.NewProvider(),
+				Transient:  memstore.NewProvider(),
+			},
 			AriesStorageProvider: &mockAriesContextProvider{},
 			PresentProofClient:   &mockpresentproof.MockClient{},
 		})

--- a/pkg/restapi/rp/operation/transient_data.go
+++ b/pkg/restapi/rp/operation/transient_data.go
@@ -1,0 +1,42 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/trustbloc/edge-core/pkg/storage"
+)
+
+type transientData struct {
+	s storage.Store
+}
+
+func newTransientStorage(s storage.Store) *transientData {
+	return &transientData{s: s}
+}
+
+func (t *transientData) Put(k string, v interface{}) error {
+	bits, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("failed to marshal transient data : %w", err)
+	}
+
+	return t.s.Put(k, bits)
+}
+
+func (t *transientData) GetConsentRequest(k string) (*consentRequestCtx, error) {
+	bits, err := t.s.Get(k)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch consentRequest with handle %s : %w", k, err)
+	}
+
+	cr := &consentRequestCtx{}
+
+	return cr, json.Unmarshal(bits, cr)
+}


### PR DESCRIPTION
closes #29 

This PR:

* Deletes `invitationData` and `thidInvitationData`
* Renames `consentRequest` -> `consentRequestCtx`. It is active right up to the point when the CHAPI request is delivered to the frontend. Stored in transient storage.
* Adds `walletResponseCtx` which replaces use of `invitationData` and `thidInvitationData` in some places. It remains stored in memory because it is active from the moment the wallet response is received (meaning there is an active network socket between the backend and the user agent) to the moment the user is redirected to Hydra.

The `oidcStates` in-memory structure was left untouched as that is referenced solely from the currently unused `hydraLoginHandler()` method. This method is likely to be refactored or deleted altogether anyway once we integrate with hub-auth.

Signed-off-by: George Aristy <george.aristy@securekey.com>
