### PR TITLE
fix: slow image build times

### DIFF
--- a/images/adapter-rest-base/Dockerfile
+++ b/images/adapter-rest-base/Dockerfile
@@ -1,0 +1,14 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+ARG GO_VER
+ARG ALPINE_VER
+
+FROM golang:${GO_VER}-alpine${ALPINE_VER}
+RUN apk add --no-cache git make
+ADD . src/github.com/trustbloc/edge-adapter
+WORKDIR src/github.com/trustbloc/edge-adapter
+RUN make adapter-rest

--- a/images/issuer-adapter-rest/Dockerfile
+++ b/images/issuer-adapter-rest/Dockerfile
@@ -4,29 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-ARG GO_VER
 ARG ALPINE_VER
 
-FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
-RUN apk add --no-cache \
-	gcc \
-	musl-dev \
-	git \
-	libtool \
-	bash \
-	npm \
-	make;
-ADD . src/github.com/trustbloc/edge-adapter
-WORKDIR src/github.com/trustbloc/edge-adapter
-ENV EXECUTABLES go git
+FROM docker.pkg.github.com/trustbloc/edge-adapter/adapter-rest-base:latest as base
 
-FROM golang as edge-adapter
-RUN make issuer-adapter-vue adapter-rest
-
-FROM alpine:${ALPINE_VER} as base
-COPY --from=edge-adapter /go/src/github.com/trustbloc/edge-adapter/.build/bin/adapter-rest /usr/local/bin
-COPY --from=edge-adapter /go/src/github.com/trustbloc/edge-adapter/.build/bin/issuer-adapter-vue /usr/local/static/issuer-adapter-vue/
-ENV ADAPTER_REST_STATIC_FILES=/usr/local/static/issuer-adapter-vue
+FROM alpine:${ALPINE_VER}
+COPY --from=base /go/src/github.com/trustbloc/edge-adapter/.build/bin/adapter-rest /usr/local/bin
+COPY .build/bin/issuer-adapter-vue /usr/local/static/issuer-adapter-vue/
+ENV ADAPTER_REST_STATIC_FILES=/usr/local/static/issuer-adapter-vue/
 ENV ADAPTER_REST_MODE=issuer
 
 # set up nsswitch.conf for Go's "netgo" implementation

--- a/images/rp-adapter-rest/Dockerfile
+++ b/images/rp-adapter-rest/Dockerfile
@@ -4,28 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-ARG GO_VER
 ARG ALPINE_VER
 
-FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
-RUN apk add --no-cache \
-	gcc \
-	musl-dev \
-	git \
-	libtool \
-	bash \
-	npm \
-	make;
-ADD . src/github.com/trustbloc/edge-adapter
-WORKDIR src/github.com/trustbloc/edge-adapter
-ENV EXECUTABLES go git
+FROM docker.pkg.github.com/trustbloc/edge-adapter/adapter-rest-base:latest as base
 
-FROM golang as edge-adapter
-RUN make rp-adapter-vue adapter-rest
-
-FROM alpine:${ALPINE_VER} as base
-COPY --from=edge-adapter /go/src/github.com/trustbloc/edge-adapter/.build/bin/adapter-rest /usr/local/bin
-COPY --from=edge-adapter /go/src/github.com/trustbloc/edge-adapter/.build/bin/rp-adapter-vue /usr/local/static/rp-adapter-vue/
+FROM alpine:${ALPINE_VER}
+COPY --from=base /go/src/github.com/trustbloc/edge-adapter/.build/bin/adapter-rest /usr/local/bin
+COPY .build/bin/rp-adapter-vue /usr/local/static/rp-adapter-vue/
 ENV ADAPTER_REST_STATIC_FILES=/usr/local/static/rp-adapter-vue
 ENV ADAPTER_REST_MODE=rp
 


### PR DESCRIPTION
* GO_VER and ALPINE_VER bumped up to 1.14.6 and 3.12 respectively
* Separate make recipe for base adapter docker image
* Use host to build Vue sites

Comparisons:

Old:
```
$ time make rp-adapter-rest-docker issuer-adapter-rest-docker
    ....
real    3m42.125s
user    0m4.139s
sys     0m2.639s
```

New:
```
$ time make rp-adapter-rest-docker issuer-adapter-rest-docker
    ....
real    1m59.907s
user    0m44.375s
sys     0m5.544s
```

Size of images remain the same at roughly 33MB.

Signed-off-by: George Aristy <george.aristy@securekey.com>