### PR TITLE
chore: copy aries framework presentation-exchange API

### DIFF
--- a/cmd/adapter-rest/go.sum
+++ b/cmd/adapter-rest/go.sum
@@ -4,6 +4,10 @@ cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSR
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/gval v1.0.1/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ module github.com/trustbloc/edge-adapter
 go 1.14
 
 require (
+	github.com/PaesslerAG/gval v1.0.1
+	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,12 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/gval v1.0.1 h1:QnCvok0w0Y3uZNxmNmC6GZ0cuBl+jH0tu/rBMT8pso4=
+github.com/PaesslerAG/gval v1.0.1/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/pkg/presexch/api.go
+++ b/pkg/presexch/api.go
@@ -1,0 +1,267 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package presexch is a copy of aries-framework-go's API imported here temporarily.
+// TODO delete this package once aries-framework-go's legacy KMS has been removed:
+//  https://github.com/trustbloc/edge-adapter/issues/241
+package presexch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/PaesslerAG/gval"
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/piprate/json-gold/ld"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+)
+
+const (
+	// PresentationSubmissionJSONLDContext is the JSONLD context of presentation submissions.
+	PresentationSubmissionJSONLDContext = "https://identity.foundation/presentation-exchange/submission/v1"
+	// PresentationSubmissionJSONLDType is the JSONLD type of presentation submissions.
+	PresentationSubmissionJSONLDType = "PresentationSubmission"
+
+	submissionProperty    = "presentation_submission"
+	descriptorMapProperty = "descriptor_map"
+)
+
+// PresentationDefinitions presentation definitions (https://identity.foundation/presentation-exchange/).
+type PresentationDefinitions struct {
+	Name             string             `json:"name"`
+	Purpose          string             `json:"purpose"`
+	InputDescriptors []*InputDescriptor `json:"input_descriptors,omitempty"`
+}
+
+// InputDescriptor input descriptors.
+type InputDescriptor struct {
+	ID     string  `json:"id,omitempty"`
+	Schema *Schema `json:"schema,omitempty"`
+}
+
+// Schema input descriptor schema.
+type Schema struct {
+	URI     string `json:"uri,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Purpose string `json:"purpose,omitempty"`
+}
+
+// PresentationSubmission is the container for the descriptor_map:
+// https://identity.foundation/presentation-exchange/#presentation-submission.
+type PresentationSubmission struct {
+	DescriptorMap []*InputDescriptorMapping `json:"descriptor_map"`
+}
+
+// InputDescriptorMapping maps an InputDescriptor to a verifiable credential pointed to by the JSONPath in `Path`.
+type InputDescriptorMapping struct {
+	ID   string `json:"id"`
+	Path string `json:"path"`
+}
+
+// MatchOptions is a holder of options that can set when matching a submission against definitions.
+type MatchOptions struct {
+	JSONLDDocumentLoader ld.DocumentLoader
+}
+
+// MatchOption is an option that sets an option for when matching.
+type MatchOption func(*MatchOptions)
+
+// WithJSONLDDocumentLoader sets the loader to use when parsing the embedded verifiable credentials.
+func WithJSONLDDocumentLoader(l ld.DocumentLoader) MatchOption {
+	return func(m *MatchOptions) {
+		m.JSONLDDocumentLoader = l
+	}
+}
+
+// Match returns the credentials matched against the InputDescriptors ids.
+func (p *PresentationDefinitions) Match(vp *verifiable.Presentation, // nolint:gocyclo,funlen
+	options ...MatchOption) (map[string]*verifiable.Credential, error) {
+	opts := &MatchOptions{}
+
+	for i := range options {
+		options[i](opts)
+	}
+
+	err := checkJSONLDContextType(vp)
+	if err != nil {
+		return nil, err
+	}
+
+	vpBits, err := vp.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal vp: %w", err)
+	}
+
+	typelessVP := interface{}(nil)
+
+	err = json.Unmarshal(vpBits, &typelessVP)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal vp: %w", err)
+	}
+
+	descriptorIDs := descriptorIDs(p.InputDescriptors)
+
+	descriptorMap, err := parseDescriptorMap(vp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse descriptor map: %w", err)
+	}
+
+	builder := gval.Full(jsonpath.PlaceholderExtension())
+	result := make(map[string]*verifiable.Credential)
+
+	for i := range descriptorMap {
+		mapping := descriptorMap[i]
+		// The object MUST include an id property, and its value MUST be a string matching the id property of
+		// the Input Descriptor in the Presentation Definition the submission is related to.
+		if !stringsContain(descriptorIDs, mapping.ID) {
+			return nil, fmt.Errorf(
+				"an %s ID was found that did not match the `id` property of any input descriptor: %s",
+				descriptorMapProperty, mapping.ID)
+		}
+
+		vc, selectErr := selectByPath(builder, typelessVP, mapping.Path, opts.JSONLDDocumentLoader)
+		if selectErr != nil {
+			return nil, fmt.Errorf("failed to select vc from submission: %w", selectErr)
+		}
+
+		inputDescriptor := p.inputDescriptor(mapping.ID)
+
+		// The schema of the candidate input must match one of the Input Descriptor schema object uri values exactly.
+		if !stringsContain(vc.Context, inputDescriptor.Schema.URI) {
+			return nil, fmt.Errorf(
+				"input descriptor id [%s] requires schema uri [%s] which is not in vc context [%+v]",
+				inputDescriptor.ID, inputDescriptor.Schema.URI, vc.Types,
+			)
+		}
+
+		result[mapping.ID] = vc
+	}
+
+	err = p.evalSubmissionRequirements(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed submission requirements: %w", err)
+	}
+
+	return result, nil
+}
+
+// Ensures the matched credentials meet the submission requirements.
+func (p *PresentationDefinitions) evalSubmissionRequirements(matched map[string]*verifiable.Credential) error {
+	descriptorIDs := descriptorIDs(p.InputDescriptors)
+
+	for i := range descriptorIDs {
+		_, found := matched[descriptorIDs[i]]
+		if !found {
+			return fmt.Errorf("no credential provided for input descriptor %s", descriptorIDs[i])
+		}
+	}
+
+	return nil
+}
+
+func (p *PresentationDefinitions) inputDescriptor(id string) *InputDescriptor {
+	for i := range p.InputDescriptors {
+		if p.InputDescriptors[i].ID == id {
+			return p.InputDescriptors[i]
+		}
+	}
+
+	return nil
+}
+
+func checkJSONLDContextType(vp *verifiable.Presentation) error {
+	if !stringsContain(vp.Context, PresentationSubmissionJSONLDContext) {
+		return fmt.Errorf("input verifiable presentation must have json-ld context %s", PresentationSubmissionJSONLDContext)
+	}
+
+	if !stringsContain(vp.Type, PresentationSubmissionJSONLDType) {
+		return fmt.Errorf("input verifiable presentation must have json-ld type %s", PresentationSubmissionJSONLDType)
+	}
+
+	return nil
+}
+
+func parseDescriptorMap(vp *verifiable.Presentation) ([]*InputDescriptorMapping, error) {
+	submission, ok := vp.CustomFields[submissionProperty].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("missing '%s' on verifiable presentation", submissionProperty)
+	}
+
+	descriptorMap, ok := submission[descriptorMapProperty].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("missing '%s' on verifiable presentation", descriptorMapProperty)
+	}
+
+	bits, err := json.Marshal(descriptorMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal descriptor map: %w", err)
+	}
+
+	typedDescriptorMap := make([]*InputDescriptorMapping, len(descriptorMap))
+
+	err = json.Unmarshal(bits, &typedDescriptorMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal descriptor map: %w", err)
+	}
+
+	return typedDescriptorMap, nil
+}
+
+func descriptorIDs(input []*InputDescriptor) []string {
+	ids := make([]string, len(input))
+
+	for i := range input {
+		ids[i] = input[i].ID
+	}
+
+	return ids
+}
+
+// [The Input Descriptor Mapping Object] MUST include a path property, and its value MUST be a JSONPath
+// string expression that selects the credential to be submit in relation to the identified Input Descriptor
+// identified, when executed against the top-level of the object the Presentation Submission is embedded within.
+func selectByPath(builder gval.Language, vp interface{}, jsonPath string,
+	loader ld.DocumentLoader) (*verifiable.Credential, error) {
+	path, err := builder.NewEvaluable(jsonPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build new json path evaluator: %w", err)
+	}
+
+	cred, err := path(context.TODO(), vp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate json path [%s]: %w", jsonPath, err)
+	}
+
+	credBits, err := json.Marshal(cred)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal credential: %w", err)
+	}
+
+	vcOpts := make([]verifiable.CredentialOpt, 0)
+
+	if loader != nil {
+		vcOpts = append(vcOpts, verifiable.WithJSONLDDocumentLoader(loader))
+	}
+
+	vc, err := verifiable.ParseCredential(credBits, vcOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse credential: %w", err)
+	}
+
+	return vc, nil
+}
+
+func stringsContain(s []string, val string) bool {
+	for i := range s {
+		if s[i] == val {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/presexch/api_test.go
+++ b/pkg/presexch/api_test.go
@@ -1,0 +1,387 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package presexch
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/piprate/json-gold/ld"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+)
+
+func TestPresentationDefinitions_Match(t *testing.T) {
+	t.Run("match one credential", func(t *testing.T) {
+		uri := randomURI()
+		expected := newVC([]string{uri})
+		defs := &PresentationDefinitions{
+			InputDescriptors: []*InputDescriptor{{
+				ID: uuid.New().String(),
+				Schema: &Schema{
+					URI: uri,
+				},
+			}},
+		}
+
+		matched, err := defs.Match(newVP(t,
+			&PresentationSubmission{DescriptorMap: []*InputDescriptorMapping{{
+				ID:   defs.InputDescriptors[0].ID,
+				Path: "$.verifiableCredential[0]",
+			}}},
+			expected,
+		), WithJSONLDDocumentLoader(jsonldContextLoader(t, uri)))
+		require.NoError(t, err)
+		require.Len(t, matched, 1)
+		result, ok := matched[defs.InputDescriptors[0].ID]
+		require.True(t, ok)
+		require.Equal(t, expected.ID, result.ID)
+	})
+
+	t.Run("error if vp does not have the right context", func(t *testing.T) {
+		uri := randomURI()
+		defs := &PresentationDefinitions{
+			InputDescriptors: []*InputDescriptor{{
+				ID: uuid.New().String(),
+				Schema: &Schema{
+					URI: uri,
+				},
+			}},
+		}
+
+		vp := newVP(t,
+			&PresentationSubmission{DescriptorMap: []*InputDescriptorMapping{{
+				ID:   defs.InputDescriptors[0].ID,
+				Path: "$.verifiableCredential[0]",
+			}}},
+			newVC([]string{uri}),
+		)
+
+		vp.Context = []string{"https://www.w3.org/2018/credentials/v1"}
+
+		_, err := defs.Match(vp, WithJSONLDDocumentLoader(jsonldContextLoader(t, uri)))
+		require.Error(t, err)
+	})
+
+	t.Run("error if vp does not have the right type", func(t *testing.T) {
+		uri := randomURI()
+		defs := &PresentationDefinitions{
+			InputDescriptors: []*InputDescriptor{{
+				ID: uuid.New().String(),
+				Schema: &Schema{
+					URI: uri,
+				},
+			}},
+		}
+
+		vp := newVP(t,
+			&PresentationSubmission{DescriptorMap: []*InputDescriptorMapping{{
+				ID:   defs.InputDescriptors[0].ID,
+				Path: "$.verifiableCredential[0]",
+			}}},
+			newVC([]string{uri}),
+		)
+
+		vp.Type = []string{"VerifiablePresentation"}
+
+		_, err := defs.Match(vp, WithJSONLDDocumentLoader(jsonldContextLoader(t, uri)))
+		require.Error(t, err)
+	})
+
+	t.Run("error if descriptor_map has an invalid ID", func(t *testing.T) {
+		uri := randomURI()
+		defs := &PresentationDefinitions{
+			InputDescriptors: []*InputDescriptor{{
+				ID: uuid.New().String(),
+				Schema: &Schema{
+					URI: uri,
+				},
+			}},
+		}
+
+		_, err := defs.Match(newVP(t,
+			&PresentationSubmission{DescriptorMap: []*InputDescriptorMapping{{
+				ID:   "INVALID",
+				Path: "$.verifiableCredential[0]",
+			}}},
+			newVC([]string{uri}),
+		), WithJSONLDDocumentLoader(jsonldContextLoader(t, uri)))
+		require.Error(t, err)
+	})
+
+	t.Run("error if jsonpath in descriptor_map points to a nonexistent element", func(t *testing.T) {
+		uri := randomURI()
+		defs := &PresentationDefinitions{
+			InputDescriptors: []*InputDescriptor{{
+				ID: uuid.New().String(),
+				Schema: &Schema{
+					URI: uri,
+				},
+			}},
+		}
+
+		_, err := defs.Match(newVP(t,
+			&PresentationSubmission{DescriptorMap: []*InputDescriptorMapping{{
+				ID:   defs.InputDescriptors[0].ID,
+				Path: "$.verifiableCredential[1]",
+			}}}, nil,
+		), WithJSONLDDocumentLoader(jsonldContextLoader(t, uri)))
+		require.Error(t, err)
+	})
+
+	t.Run("error if cannot parse credential", func(t *testing.T) {
+		uri := randomURI()
+		defs := &PresentationDefinitions{
+			InputDescriptors: []*InputDescriptor{{
+				ID: uuid.New().String(),
+				Schema: &Schema{
+					URI: uri,
+				},
+			}},
+		}
+
+		_, err := defs.Match(newVP(t,
+			&PresentationSubmission{DescriptorMap: []*InputDescriptorMapping{{
+				ID:   defs.InputDescriptors[0].ID,
+				Path: "$.verifiableCredential[0]",
+			}}}, newVC([]string{uri}),
+		))
+		require.Error(t, err)
+	})
+
+	t.Run("error if embedded credential has a type different than the input descriptor schema uri", func(t *testing.T) {
+		uri := randomURI()
+		defs := &PresentationDefinitions{
+			InputDescriptors: []*InputDescriptor{{
+				ID: uuid.New().String(),
+				Schema: &Schema{
+					URI: uri,
+				},
+			}},
+		}
+
+		diffURI := randomURI()
+		require.NotEqual(t, uri, diffURI)
+
+		_, err := defs.Match(newVP(t,
+			&PresentationSubmission{DescriptorMap: []*InputDescriptorMapping{{
+				ID:   defs.InputDescriptors[0].ID,
+				Path: "$.verifiableCredential[0]",
+			}}},
+			newVC([]string{diffURI}),
+		), WithJSONLDDocumentLoader(jsonldContextLoader(t, diffURI)))
+		require.Error(t, err)
+	})
+
+	t.Run("error when missing required credential", func(t *testing.T) {
+		uriOne := randomURI()
+		uriTwo := randomURI()
+		defs := &PresentationDefinitions{
+			InputDescriptors: []*InputDescriptor{
+				{
+					ID: uuid.New().String(),
+					Schema: &Schema{
+						URI: uriOne,
+					},
+				},
+				{
+					ID: uuid.New().String(),
+					Schema: &Schema{
+						URI: uriTwo,
+					},
+				},
+			},
+		}
+
+		_, err := defs.Match(newVP(t,
+			&PresentationSubmission{DescriptorMap: []*InputDescriptorMapping{{
+				ID:   defs.InputDescriptors[0].ID,
+				Path: "$.verifiableCredential[0]",
+			}}},
+			newVC([]string{uriOne}),
+		), WithJSONLDDocumentLoader(jsonldContextLoader(t, uriOne)))
+		require.Error(t, err)
+	})
+
+	t.Run("error if embedded credential has a type different than the input descriptor schema uri", func(t *testing.T) {
+		uri := randomURI()
+		defs := &PresentationDefinitions{
+			InputDescriptors: []*InputDescriptor{{
+				ID: uuid.New().String(),
+				Schema: &Schema{
+					URI: uri,
+				},
+			}},
+		}
+
+		_, err := defs.Match(newVP(t,
+			nil,
+			newVC([]string{uri}),
+		), WithJSONLDDocumentLoader(jsonldContextLoader(t, uri)))
+		require.Error(t, err)
+	})
+
+	t.Run("error if descriptor_map has an invalid ID", func(t *testing.T) {
+		uri := randomURI()
+		defs := &PresentationDefinitions{
+			InputDescriptors: []*InputDescriptor{{
+				ID: uuid.New().String(),
+				Schema: &Schema{
+					URI: uri,
+				},
+			}},
+		}
+
+		_, err := defs.Match(newVP(t,
+			&PresentationSubmission{},
+			newVC([]string{uri}),
+		), WithJSONLDDocumentLoader(jsonldContextLoader(t, uri)))
+		require.Error(t, err)
+	})
+}
+
+func TestE2E(t *testing.T) {
+	// verifier sends their presentation definitions to the holder
+	verifierDefinitions := &PresentationDefinitions{
+		InputDescriptors: []*InputDescriptor{{
+			ID: uuid.New().String(),
+			Schema: &Schema{
+				URI: randomURI(),
+			},
+		}},
+	}
+
+	// holder builds their presentation submission against the verifier's definitions
+	holderCredential := newVC([]string{verifierDefinitions.InputDescriptors[0].Schema.URI})
+	vp := newVP(t,
+		&PresentationSubmission{DescriptorMap: []*InputDescriptorMapping{{
+			ID:   verifierDefinitions.InputDescriptors[0].ID,
+			Path: "$.verifiableCredential[0]",
+		}}},
+		holderCredential,
+	)
+
+	// holder sends VP over the wire to the verifier
+	vpBytes := marshal(t, vp)
+
+	// verifier parses the vp
+	receivedVP, err := verifiable.ParseUnverifiedPresentation(vpBytes)
+	require.NoError(t, err)
+
+	// verifier matches the received VP against their definitions
+	matched, err := verifierDefinitions.Match(
+		receivedVP,
+		WithJSONLDDocumentLoader(
+			jsonldContextLoader(t, verifierDefinitions.InputDescriptors[0].Schema.URI)))
+	require.NoError(t, err)
+	require.Len(t, matched, 1)
+	result, ok := matched[verifierDefinitions.InputDescriptors[0].ID]
+	require.True(t, ok)
+	require.Equal(t, holderCredential.ID, result.ID)
+}
+
+func newVC(context []string) *verifiable.Credential {
+	vc := &verifiable.Credential{
+		ID:      "http://test.credential.com/123",
+		Context: []string{"https://www.w3.org/2018/credentials/v1"},
+		Types:   []string{"VerifiableCredential"},
+		Issuer:  verifiable.Issuer{ID: "http://test.issuer.com"},
+		Issued: &util.TimeWithTrailingZeroMsec{
+			Time: time.Now(),
+		},
+		Subject: map[string]interface{}{
+			"id": uuid.New().String(),
+		},
+	}
+
+	if context != nil {
+		vc.Context = append(vc.Context, context...)
+	}
+
+	return vc
+}
+
+func newVP(t *testing.T, submission *PresentationSubmission, vcs ...*verifiable.Credential) *verifiable.Presentation {
+	vp := &verifiable.Presentation{
+		Context: []string{
+			"https://www.w3.org/2018/credentials/v1",
+			"https://identity.foundation/presentation-exchange/submission/v1",
+		},
+		Type: []string{
+			"VerifiablePresentation",
+			"PresentationSubmission",
+		},
+	}
+
+	if submission != nil {
+		vp.CustomFields = make(map[string]interface{})
+		vp.CustomFields["presentation_submission"] = toMap(t, submission)
+	}
+
+	if len(vcs) > 0 {
+		creds := make([]interface{}, len(vcs))
+
+		for i := range vcs {
+			creds[i] = vcs[i]
+		}
+
+		err := vp.SetCredentials(creds...)
+		require.NoError(t, err)
+	}
+
+	return vp
+}
+
+func toMap(t *testing.T, v interface{}) map[string]interface{} {
+	bits, err := json.Marshal(v)
+	require.NoError(t, err)
+
+	m := make(map[string]interface{})
+
+	err = json.Unmarshal(bits, &m)
+	require.NoError(t, err)
+
+	return m
+}
+
+func marshal(t *testing.T, v interface{}) []byte {
+	bits, err := json.Marshal(v)
+	require.NoError(t, err)
+
+	return bits
+}
+
+func randomURI() string {
+	return fmt.Sprintf("https://my.test.context.jsonld/%s", uuid.New().String())
+}
+
+func jsonldContextLoader(t *testing.T, contextURL string) *ld.CachingDocumentLoader {
+	const jsonLDContext = `{
+    "@context":{
+      "@version":1.1,
+      "@protected":true,
+      "name":"http://schema.org/name",
+      "ex":"https://example.org/examples#",
+      "xsd":"http://www.w3.org/2001/XMLSchema#"
+   }
+}`
+
+	reader, err := ld.DocumentFromReader(strings.NewReader(jsonLDContext))
+	require.NoError(t, err)
+
+	loader := verifiable.CachingJSONLDLoader()
+
+	loader.AddDocument(contextURL, reader)
+
+	return loader
+}

--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -11,8 +11,8 @@ function filterExcludedFiles {
   CHECK=`echo "$CHECK" | grep -v .png$ | grep -v .rst$ | grep -v ^.git/ \
   | grep -v .pem$ | grep -v .block$ | grep -v .tx$ | grep -v ^LICENSE$ | grep -v _sk$ \
   | grep -v .key$ | grep -v .crt$ | grep -v \\.gen.go$ | grep -v \\.json$ | grep -v \\.jsonld | grep -v Gopkg.lock$ \
-  | grep -v .md$ || grep -v .svg$  grep -v ^vendor/ | grep -v ^build/ | grep -v .pb.go$ | grep -v ci.properties$ \
-  | grep -v go.sum$ |sort -u`
+  | grep -v .md$ | grep -v .svg$ | grep -v ^vendor/ | grep -v ^build/ | grep -v .pb.go$ | grep -v ci.properties$ \
+  | grep -v go.sum$ | sort -u`
 }
 
 CHECK=$(git diff --name-only --diff-filter=ACMRTUXB HEAD)

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -11,6 +11,10 @@ github.com/Microsoft/go-winio v0.4.15-0.20200113171025-3fe6c5262873/go.mod h1:tT
 github.com/Microsoft/hcsshim v0.8.7 h1:ptnOoufxGSzauVTsdE+wMYnCWA301PdoN4xg5oRdZpg=
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/gval v1.0.1/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=


### PR DESCRIPTION
This is a temporary solution.

The existing models in the `presentationex` package will be removed in task #234

closes #239 

This PR also fixes a typo in `check_license.sh`

Signed-off-by: George Aristy <george.aristy@securekey.com>