### PR TITLE
feat: Support for Credential with Assurance Credential flow

### DIFF
--- a/pkg/profile/issuer/profile.go
+++ b/pkg/profile/issuer/profile.go
@@ -31,13 +31,14 @@ type Profile struct {
 
 // ProfileData struct for profile.
 type ProfileData struct {
-	ID                     string     `json:"id,omitempty"`
-	Name                   string     `json:"name"`
-	URL                    string     `json:"url"`
-	SupportedVCContexts    []string   `json:"supportedVCContexts"`
-	CredentialSigningKey   string     `json:"credentialSigningKey"`
-	PresentationSigningKey string     `json:"presentationSigningKey"`
-	CreatedAt              *time.Time `json:"createdAt"`
+	ID                          string     `json:"id,omitempty"`
+	Name                        string     `json:"name"`
+	URL                         string     `json:"url"`
+	SupportedVCContexts         []string   `json:"supportedVCContexts"`
+	SupportsAssuranceCredential bool       `json:"SupportsAssuranceCredential"`
+	CredentialSigningKey        string     `json:"credentialSigningKey"`
+	PresentationSigningKey      string     `json:"presentationSigningKey"`
+	CreatedAt                   *time.Time `json:"createdAt"`
 }
 
 // New returns new issuer profile instance.

--- a/pkg/restapi/issuer/operation/models.go
+++ b/pkg/restapi/issuer/operation/models.go
@@ -16,10 +16,11 @@ import (
 
 // ProfileDataRequest req for profile creation.
 type ProfileDataRequest struct {
-	ID                  string   `json:"id,omitempty"`
-	Name                string   `json:"name"`
-	SupportedVCContexts []string `json:"supportedVCContexts"`
-	URL                 string   `json:"url"`
+	ID                          string   `json:"id,omitempty"`
+	Name                        string   `json:"name"`
+	SupportedVCContexts         []string `json:"supportedVCContexts"`
+	SupportsAssuranceCredential bool     `json:"SupportsAssuranceCredential"`
+	URL                         string   `json:"url"`
 }
 
 // WalletConnect response from wallet.
@@ -40,6 +41,7 @@ type CHAPIRequest struct {
 	Query                *CHAPIQuery           `json:"query,omitempty"`
 	DIDCommInvitation    *outofband.Invitation `json:"invitation,omitempty"`
 	Manifest             json.RawMessage       `json:"manifest,omitempty"`
+	Credentials          []json.RawMessage     `json:"credentials,omitempty"`
 	CredentialGovernance json.RawMessage       `json:"credentialGovernance,omitempty"`
 }
 
@@ -103,4 +105,9 @@ type IssuerTokenReq struct {
 // IssuerTokenResp issuer user data token response.
 type IssuerTokenResp struct {
 	Token string `json:"token,omitempty"`
+}
+
+// ReferenceCredentialData reference credential data.
+type ReferenceCredentialData struct {
+	ID string `json:"id,omitempty"`
 }

--- a/pkg/vc/api.go
+++ b/pkg/vc/api.go
@@ -20,6 +20,12 @@ const (
 
 	// VerifiableCredentialContext vc base context.
 	VerifiableCredentialContext = "https://www.w3.org/2018/credentials/v1"
+
+	// AssuranceCredentialContext is the JSON-LD context for the AssuranceCredential.
+	AssuranceCredentialContext = "https://trustbloc.github.io/context/vc/assurance-credential-v1.jsonld"
+
+	// AssuranceCredentialType is the JSON-LD type for the AssuranceCredential.
+	AssuranceCredentialType = "AssuranceCredential"
 )
 
 // Crypto vc/vp signing apis.

--- a/test/bdd/cmd/issuer/go.mod
+++ b/test/bdd/cmd/issuer/go.mod
@@ -7,6 +7,7 @@ module github.com/trustbloc/edge-adapter/test/bdd/cmd/issuer
 go 1.14
 
 require (
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
 	github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63
 )

--- a/test/bdd/cmd/issuer/go.sum
+++ b/test/bdd/cmd/issuer/go.sum
@@ -41,6 +41,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20200209183636-89e6cbcd0b6d/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=

--- a/test/bdd/features/issuer_e2e.feature
+++ b/test/bdd/features/issuer_e2e.feature
@@ -9,18 +9,19 @@
 Feature: Issuer Adapter e2e
 
   Scenario Outline: Issuer adapter features
-    Given Issuer Profile with id "<profileID>", name "<profileName>", issuerURL "<issuerURL>" and supportedVCContexts "<supportedVCContexts>"
-    And   Retrieved profile with id "<profileID>" contains name "<profileName>", issuerURL "<issuerURL>" and supportedVCContexts "<supportedVCContexts>"
+    Given Issuer Profile with id "<profileID>", name "<profileName>", issuerURL "<issuerURL>", supportedVCContexts "<supportedVCContexts>" and supportsAssuranceCred "<supportsAssuranceCred>"
+    And   Retrieved profile with id "<profileID>" contains name "<profileName>", issuerURL "<issuerURL>", supportedVCContexts "<supportedVCContexts>" and supportsAssuranceCred "<supportsAssuranceCred>"
     Given "Wallet" agent is running on "localhost" port "9081" with controller "http://localhost:9082"
     Then  Issuer adapter shows the wallet connect UI when the issuer "<profileID>" wants to connect to the wallet
     And   Issuer adapter ("<profileID>") creates DIDComm connection invitation for "Wallet"
     ## Mocking CHAPI flow here
-    Then  "Wallet" validates the supportedVCContexts "<supportedVCContexts>" in connect request from Issuer adapter ("<profileID>") and responds within "5" seconds
+    Then  "Wallet" validates the supportedVCContexts "<supportedVCContexts>" in connect request from Issuer adapter ("<profileID>") along with primary credential type "<primaryVCType>" in case of supportsAssuranceCred "<supportsAssuranceCred>" and responds within "5" seconds
     And   Issuer adapter ("<profileID>") validates response from "Wallet" and redirects to "<issuerURL>"
     When  "Wallet" sends request credential message and receives credential from the issuer ("<profileID>")
     ## Mocking RP present proof call here (wallet calls instead of RP here)
-    Then  "Wallet" sends present proof request message to the the issuer ("<profileID>") and validates that the vc inside vp contains type "<vcType>"
+    Then  "Wallet" sends present proof request message to the the issuer ("<profileID>") and validates that the vc inside vp contains type "<authZFlowVCType>" along with supportsAssuranceCred "<supportsAssuranceCred>" validation
     Examples:
-      | profileID     | profileName           | issuerURL                                 | supportedVCContexts                                                       | vcType                  |
-      | prCard        | PRCard Issuer         | http://issuer.example.com:9080/prCard     | https://w3id.org/citizenship/v3                                           | PermanentResidentCard   |
-      | creditCard    | CreditCard Issuer     | http://issuer.example.com:9080/creditCard | https://trustbloc.github.io/context/vc/examples/credit-card-v1.jsonld     | CreditCardStatement     |
+      | profileID       | profileName                           | issuerURL                                         | supportedVCContexts                                                                  | supportsAssuranceCred   | authZFlowVCType         | primaryVCType     |
+      | prCard          | PRCard Issuer                         | http://issuer.example.com:9080/prCard             | https://w3id.org/citizenship/v3                                                      | false                   | PermanentResidentCard   |                   |
+      | creditCard      | CreditCard Issuer                     | http://issuer.example.com:9080/creditCard         | https://trustbloc.github.io/context/vc/examples/credit-card-v1.jsonld                | false                   | CreditCardStatement     |                   |
+      | driversLicense  | Drivers License wth Evidence Issuer   | http://issuer.example.com:9080/driversLicense     | https://trustbloc.github.io/context/vc/examples/driver-license-evidence-v1.jsonld    | true                    | DrivingLicenseEvidence  | mDL               |


### PR DESCRIPTION
- New option while creating the profile
- CHAPI Request contains Reference VC and Manifest of Assurance VC along with DIDConnect Invitation
- New Issuer API to fetch assurance data

closes #260 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>