### PR TITLE
refactor: #277 rp-adapter id_token response

### DIFF
--- a/pkg/presentationex/provider.go
+++ b/pkg/presentationex/provider.go
@@ -11,8 +11,6 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/google/uuid"
-
 	"github.com/trustbloc/edge-adapter/pkg/presexch"
 )
 
@@ -51,7 +49,7 @@ func (p *Provider) Create(scopes []string) (*presexch.PresentationDefinitions, e
 			return nil, fmt.Errorf("scope [%s] not supported", scope)
 		}
 
-		def.ID = uuid.New().String()
+		def.ID = scope
 		defs.InputDescriptors = append(defs.InputDescriptors, def)
 	}
 

--- a/pkg/restapi/rp/operation/operations_test.go
+++ b/pkg/restapi/rp/operation/operations_test.go
@@ -2189,7 +2189,12 @@ func TestHandleUserDataSuccess(t *testing.T) {
 		c.issuerCallbackTimeout = time.Second
 		require.NoError(t, err)
 		w := httptest.NewRecorder()
-		c.handleUserDataSuccess(w, nil, []*verifiable.Credential{invalid}, &consentRequestCtx{})
+		c.handleUserDataSuccess(w,
+			nil,
+			map[string]*verifiable.Credential{
+				"scope": invalid,
+			},
+			&consentRequestCtx{})
 		require.Equal(t, http.StatusInternalServerError, w.Code)
 	})
 
@@ -2213,7 +2218,9 @@ func TestHandleUserDataSuccess(t *testing.T) {
 		w := httptest.NewRecorder()
 		c.handleUserDataSuccess(w,
 			newCHAPIResponse(t, "", vp),
-			[]*verifiable.Credential{ccVC},
+			map[string]*verifiable.Credential{
+				"scope": ccVC,
+			},
 			&consentRequestCtx{
 				CR: &admin.GetConsentRequestOK{Payload: &models.ConsentRequest{}},
 			},


### PR DESCRIPTION
closes #277 

The RP Adapter now returns OIDC aggregate claims, where each claim source object is a `verified_claims` element:
https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html#section-5.

Each member name of `_claim_names` is one of the requested scopes. These do not include [standard OIDC scopes](https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims). These are likely to be included as standard top-level claims once user SSO authentication is implemented. 

Each value of `_claim_sources` is a `verified_claims` object. This is different than standard OIDC [aggregate && distributed claims](https://openid.net/specs/openid-connect-core-1_0.html#AggregatedDistributedClaims) because the spec mandates these objects be JWTs (for aggregate claims). The RP Adapter does not deliver aggregate JWTs from the issuers because it cannot transform signed VCs into JWTs. Even if the VCs are issued in JWT format by the issuers, would those blinded signatures mean anything to the RP? 

The aggregate user data is under the `claims` member of this object. A sibling `verification` element will be added in the future. This element will hold verification metadata such as the trust framework, assurance, etc. See example [here](https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html#section-5).

<details><summary>Example</summary>

```json
{                                                                                                                                                                                                                  
    "aud": [
        "7a16ad61-f561-4bda-819d-71922a39fc5b"
    ],
    "auth_time": 1598311017,
    "at_hash": "L1eTjFL7TncgYiyEtBeqww",
    "exp": 1598314620,
    "iat": 1598311020,
    "iss": "https://localhost:4444/",
    "jti": "5343d94c-7816-4c7d-aae3-009a3fe05886",
    "nonce": "",
    "rat": 1598311017,
    "sid": "2140c597-90a3-4a5b-b331-9decfd73677c",

    "sub": "e49b2ca2-340d-4660-b214-797f05b918a5",

    "_claim_names": {
        "credit_card_stmt:remote": "src1",
        "driver_license:local": "src2"
    },
    "_claim_sources": {
        "src1": {
            "claims": {
                "id": "did:peer:user",
                "stmt": {
                    "accountId": "xxxx-xxxx-xxxx-1234",
                    "billingPeriod": "P30D",
                    "customer": {
                        "@type": "Person",
                        "name": "Jane Doe"
                    },
                    "description": "June 2020 Credit Card Statement",
                    "minimumPaymentDue": {
                        "@type": "PriceSpecification",
                        "price": 15,
                        "priceCurrency": "CAD"
                    },
                    "paymentDueDate": "2020-06-30T12:00:00",
                    "paymentStatus": "http://schema.org/PaymentDue",
                    "totalPaymentDue": {
                        "@type": "PriceSpecification",
                        "price": 200,
                        "priceCurrency": "CAD"
                    },
                    "url": "http://acmebank.com/invoice.pdf"
                }
            }
        },
        "src2": {
            "claims": {
                "document_number": "123-456-789",
                "family_name": "Smith",
                "given_name": "John",
                "id": "did:peer:user"
            }
        }
    }
```

</details>

Signed-off-by: George Aristy <george.aristy@securekey.com>