### PR TITLE
refactor: [Issuer Adapter] Remove 'manifest' attribute in chapi request

### DIFF
--- a/pkg/restapi/issuer/operation/models.go
+++ b/pkg/restapi/issuer/operation/models.go
@@ -40,7 +40,6 @@ type txnData struct {
 type CHAPIRequest struct {
 	Query                *CHAPIQuery           `json:"query,omitempty"`
 	DIDCommInvitation    *outofband.Invitation `json:"invitation,omitempty"`
-	Manifest             json.RawMessage       `json:"manifest,omitempty"`
 	Credentials          []json.RawMessage     `json:"credentials,omitempty"`
 	CredentialGovernance json.RawMessage       `json:"credentialGovernance,omitempty"`
 }

--- a/pkg/restapi/issuer/operation/operations.go
+++ b/pkg/restapi/issuer/operation/operations.go
@@ -473,11 +473,8 @@ func (o *Operation) getCHAPIRequestHandler(rw http.ResponseWriter, req *http.Req
 	}
 
 	commhttp.WriteResponseWithLog(rw, &CHAPIRequest{
-		Query:             &CHAPIQuery{Type: DIDConnectCHAPIQueryType},
-		DIDCommInvitation: txnData.DIDCommInvitation,
-		// TODO - https://github.com/trustbloc/edge-adapter/issues/281 Remove manifest attribute once
-		//  wallet is updated, as it would be part of credentials array
-		Manifest:             manifestVC,
+		Query:                &CHAPIQuery{Type: DIDConnectCHAPIQueryType},
+		DIDCommInvitation:    txnData.DIDCommInvitation,
 		Credentials:          credentials,
 		CredentialGovernance: governanceVC,
 	}, getCHAPIRequestEndpoint, logger)
@@ -789,7 +786,7 @@ func (o *Operation) createCredential(token string, profile *issuer.ProfileData, 
 
 	credSubData, err := unmarshalSubject(resp.Data)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshal issuer resp : %w", err)
+		return nil, fmt.Errorf("unmarshal credential subject in issuer resp : %w", err)
 	}
 
 	cred := &verifiable.Credential{}


### PR DESCRIPTION
The manifest is being part of 'credentials' attribute.

closes #281 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>