### PR TITLE
chore: Upgrade to Go v1.15 and build documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ MOCK_ISSUER_IMAGE_NAME ?= mock-issuer
 
 # Tool commands (overridable)
 ALPINE_VER ?= 3.12
-GO_VER ?= 1.14
+GO_VER ?= 1.15
 GOBIN_PATH=$(abspath .)/.build/bin
 
 .PHONY: all

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The edge adapter contains following components.
 - [Issuer Adapter](./docs/issuer/README.md)
 - [Relying Party (RP) Adapter](./docs/rp/README.md) 
 
+## Build
+To build from source see [here](docs/build.md).
+
 ## Contributing
 Thank you for your interest in contributing. Please see our [community contribution guidelines](https://github.com/trustbloc/community/blob/master/CONTRIBUTING.md) for more information.
 

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
   - master
 
 variables:
-  GO_VERSION: 1.14
+  GO_VERSION: 1.15
   GOPATH: $(Agent.BuildDirectory)/go
 
 jobs:

--- a/cmd/adapter-rest/go.mod
+++ b/cmd/adapter-rest/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/edge-adapter/cmd/adapter-rest
 
-go 1.14
+go 1.15
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/cmd/adapter-rest/startcmd/start.go
+++ b/cmd/adapter-rest/startcmd/start.go
@@ -72,7 +72,7 @@ const (
 
 	datasourceTimeoutFlagName  = "dsn-timeout"
 	datasourceTimeoutFlagUsage = "Total time in seconds to wait until the datasource is available before giving up." +
-		" Default: " + string(datasourceTimeoutDefault) + " seconds." +
+		" Default: " + string(rune(datasourceTimeoutDefault)) + " seconds." +
 		" Alternatively, this can be set with the following environment variable: " + datasourceTimeoutEnvKey
 	datasourceTimeoutEnvKey  = "ADAPTER_REST_DSN_TIMEOUT"
 	datasourceTimeoutDefault = 30
@@ -463,7 +463,7 @@ func getDsnParams(cmd *cobra.Command) (*dsnParams, error) {
 	}
 
 	if timeout == "" {
-		timeout = string(datasourceTimeoutDefault)
+		timeout = string(rune(datasourceTimeoutDefault))
 	}
 
 	t, err := strconv.Atoi(timeout)

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,27 @@
+# Building and Testing
+
+## Prerequisites
+- Go 1.15
+- Docker
+- Docker-Compose
+- Make
+- bash
+- Configure Docker to use GitHub Packages: [Authenticate](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages) 
+  using a [GitHub token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token) 
+
+
+## Targets
+
+```
+# run everything
+make all
+
+# linters
+make checks
+
+# unit tests
+make unit-test
+
+# BDD tests
+make bdd-test
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/edge-adapter
 
-go 1.14
+go 1.15
 
 require (
 	github.com/PaesslerAG/gval v1.0.1

--- a/test/bdd/cmd/issuer/go.mod
+++ b/test/bdd/cmd/issuer/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/edge-adapter/test/bdd/cmd/issuer
 
-go 1.14
+go 1.15
 
 require (
 	github.com/google/uuid v1.1.1

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/edge-adapter/test/bdd
 
-go 1.14
+go 1.15
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible


### PR DESCRIPTION
- Upgrade to Go v1.15
- Build document
- Link from README to build doc

part of #324 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>