### PR TITLE
chore: Add dockerignore to skip npm_modules in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+.git
+cmd/issuer-adapter-vue/node_modules
+cmd/rp-adapter-vue/node_modules


### PR DESCRIPTION
Added dockerignore file to skip npm_modules passed to docker build context. The npm_modules for RP and Issuer adapter VUE folder size is around 250MB each. Skipping these improves the docker build time.

In CI, the build time improvements is around 50% (~6min vs ~9min).
Master Build - https://dev.azure.com/trustbloc/edge/_build/results?buildId=8377&view=results
This PR Build - https://dev.azure.com/trustbloc/edge/_build/results?buildId=8378&view=logs&j=888c3ba9-6bd0-5e3d-cb39-2cba9e4c5cc5

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>