### PR TITLE
feat: wallet-bridge operations

### DIFF
--- a/pkg/aries/api.go
+++ b/pkg/aries/api.go
@@ -8,6 +8,7 @@ package aries
 
 import (
 	ariescrypto "github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
@@ -23,6 +24,7 @@ type CtxProvider interface {
 	Service(id string) (interface{}, error)
 	ServiceEndpoint() string
 	StorageProvider() storage.Provider
+	Messenger() service.Messenger
 	ProtocolStateStorageProvider() storage.Provider
 	KMS() kms.KeyManager
 	VDRegistry() vdrapi.Registry

--- a/pkg/restapi/internal/mocks/protocol/outofband.go
+++ b/pkg/restapi/internal/mocks/protocol/outofband.go
@@ -1,0 +1,80 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package protocol
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofband"
+)
+
+// MockOobService is a mock of OobService interface.
+type MockOobService struct {
+	AcceptInvitationHandle func(*outofband.Invitation, string, []string) (string, error)
+	SaveInvitationErr      error
+}
+
+// AcceptInvitation mock implementation.
+func (m *MockOobService) AcceptInvitation(arg0 *outofband.Invitation, arg1 string, arg2 []string) (string, error) {
+	if m.AcceptInvitationHandle != nil {
+		return m.AcceptInvitationHandle(arg0, arg1, arg2)
+	}
+
+	return "", nil
+}
+
+// AcceptRequest mock implementation.
+func (m *MockOobService) AcceptRequest(arg0 *outofband.Request, arg1 string, arg2 []string) (string, error) {
+	return "", nil
+}
+
+// ActionContinue mock implementation.
+func (m *MockOobService) ActionContinue(arg0 string, arg1 outofband.Options) error {
+	return nil
+}
+
+// ActionStop mock implementation.
+func (m *MockOobService) ActionStop(arg0 string, arg1 error) error {
+	return nil
+}
+
+// Actions mock implementation.
+func (m *MockOobService) Actions() ([]outofband.Action, error) {
+	return []outofband.Action{}, nil
+}
+
+// RegisterActionEvent mock implementation.
+func (m *MockOobService) RegisterActionEvent(arg0 chan<- service.DIDCommAction) error {
+	return nil
+}
+
+// RegisterMsgEvent mock implementation.
+func (m *MockOobService) RegisterMsgEvent(arg0 chan<- service.StateMsg) error {
+	return nil
+}
+
+// SaveInvitation mock implementation.
+func (m *MockOobService) SaveInvitation(arg0 *outofband.Invitation) error {
+	if m.SaveInvitationErr != nil {
+		return m.SaveInvitationErr
+	}
+
+	return nil
+}
+
+// SaveRequest mock implementation.
+func (m *MockOobService) SaveRequest(arg0 *outofband.Request) error {
+	return nil
+}
+
+// UnregisterActionEvent mock implementation.
+func (m *MockOobService) UnregisterActionEvent(arg0 chan<- service.DIDCommAction) error {
+	return nil
+}
+
+// UnregisterMsgEvent mock implementation.
+func (m *MockOobService) UnregisterMsgEvent(arg0 chan<- service.StateMsg) error {
+	return nil
+}

--- a/pkg/restapi/internal/mocks/provider/provider.go
+++ b/pkg/restapi/internal/mocks/provider/provider.go
@@ -1,0 +1,78 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package provider
+
+import (
+	"sync"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	mocksvc "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/service"
+	mockprov "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+)
+
+// MockProvider mock implementation of provider needed by sdk command controller.
+type MockProvider struct {
+	*mockprov.Provider
+	CustomMessenger service.Messenger
+}
+
+// NewMockProvider returns mock implementation of basic provider.
+func NewMockProvider() *MockProvider {
+	return &MockProvider{Provider: &mockprov.Provider{}}
+}
+
+// Messenger return mock messenger.
+func (p *MockProvider) Messenger() service.Messenger {
+	if p.CustomMessenger != nil {
+		return p.CustomMessenger
+	}
+
+	return &mocksvc.MockMessenger{}
+}
+
+// NewMockMessenger returns new mock messenger.
+func NewMockMessenger() *MockMessenger {
+	return &MockMessenger{MockMessenger: &mocksvc.MockMessenger{}}
+}
+
+// MockMessenger mock implementation of messenger.
+type MockMessenger struct {
+	*mocksvc.MockMessenger
+	lastID string
+	lock   sync.RWMutex
+}
+
+// Send mock messenger Send.
+func (m *MockMessenger) Send(msg service.DIDCommMsgMap, myDID, theirDID string) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.lastID = msg.ID()
+
+	return nil
+}
+
+// ReplyToNested mock messenger ReplyToNested.
+func (m *MockMessenger) ReplyToNested(msg service.DIDCommMsgMap, opts *service.NestedReplyOpts) error {
+	if m.ErrReplyToNested != nil {
+		return m.ErrReplyToNested
+	}
+
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.lastID = msg.ID()
+
+	return nil
+}
+
+// GetLastID returns ID of the last message received.
+func (m *MockMessenger) GetLastID() string {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.lastID
+}

--- a/pkg/restapi/issuer/controller_test.go
+++ b/pkg/restapi/issuer/controller_test.go
@@ -16,7 +16,7 @@ import (
 	presentproofsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/presentproof"
 	mocksvc "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/didexchange"
 	mockroute "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/mediator"
-	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	ariesmockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/edge-core/pkg/storage/memstore"
@@ -25,22 +25,24 @@ import (
 	"github.com/trustbloc/edge-adapter/pkg/internal/mock/messenger"
 	"github.com/trustbloc/edge-adapter/pkg/internal/mock/outofband"
 	"github.com/trustbloc/edge-adapter/pkg/internal/mock/presentproof"
+	mockprovider "github.com/trustbloc/edge-adapter/pkg/restapi/internal/mocks/provider"
 	"github.com/trustbloc/edge-adapter/pkg/restapi/issuer/operation"
 )
 
 func TestNew(t *testing.T) {
 	t.Run("test new - success", func(t *testing.T) {
-		ariesCtx := &mockprovider.Provider{
-			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:              mockstore.NewMockStoreProvider(),
-			ServiceMap: map[string]interface{}{
-				didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{},
-				mediator.Coordination:   &mockroute.MockMediatorSvc{},
-				issuecredsvc.Name:       &issuecredential.MockIssueCredentialSvc{},
-				presentproofsvc.Name:    &presentproof.MockPresentProofSvc{},
-				outofbandsvc.Name:       &outofband.MockService{},
-			},
-		}
+		ariesCtx := &mockprovider.MockProvider{
+			Provider: &ariesmockprovider.Provider{
+				ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+				StorageProviderValue:              mockstore.NewMockStoreProvider(),
+				ServiceMap: map[string]interface{}{
+					didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{},
+					mediator.Coordination:   &mockroute.MockMediatorSvc{},
+					issuecredsvc.Name:       &issuecredential.MockIssueCredentialSvc{},
+					presentproofsvc.Name:    &presentproof.MockPresentProofSvc{},
+					outofbandsvc.Name:       &outofband.MockService{},
+				},
+			}}
 
 		controller, err := New(&operation.Config{
 			AriesCtx:       ariesCtx,
@@ -57,7 +59,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("test new - fail", func(t *testing.T) {
-		ariesCtx := &mockprovider.Provider{}
+		ariesCtx := mockprovider.NewMockProvider()
 
 		controller, err := New(&operation.Config{AriesCtx: ariesCtx})
 		require.Nil(t, controller)

--- a/pkg/restapi/issuer/operation/support_test.go
+++ b/pkg/restapi/issuer/operation/support_test.go
@@ -30,7 +30,7 @@ import (
 	mocksvc "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/didexchange"
 	mockroute "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/mediator"
 	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
-	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	ariesmockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/mock/vdr"
 	"github.com/stretchr/testify/require"
@@ -44,27 +44,30 @@ import (
 	mockoutofband "github.com/trustbloc/edge-adapter/pkg/internal/mock/outofband"
 	"github.com/trustbloc/edge-adapter/pkg/internal/mock/presentproof"
 	"github.com/trustbloc/edge-adapter/pkg/profile/issuer"
+	mockprovider "github.com/trustbloc/edge-adapter/pkg/restapi/internal/mocks/provider"
 	adaptervc "github.com/trustbloc/edge-adapter/pkg/vc"
 	issuervc "github.com/trustbloc/edge-adapter/pkg/vc/issuer"
 )
 
 func getAriesCtx() aries.CtxProvider {
-	return &mockprovider.Provider{
-		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
-		StorageProviderValue:              mockstore.NewMockStoreProvider(),
-		ServiceMap: map[string]interface{}{
-			didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{},
-			mediator.Coordination:   &mockroute.MockMediatorSvc{},
-			issuecredsvc.Name:       &issuecredential.MockIssueCredentialSvc{},
-			presentproofsvc.Name:    &presentproof.MockPresentProofSvc{},
-			outofbandsvc.Name:       &mockoutofband.MockService{},
-		},
-		KMSValue:             &mockkms.KeyManager{ImportPrivateKeyErr: fmt.Errorf("error import priv key")},
-		CryptoValue:          &mockcrypto.Crypto{},
-		ServiceEndpointValue: "endpoint",
-		VDRegistryValue: &mockvdri.MockVDRegistry{
-			CreateValue:  mockdiddoc.GetMockDIDDoc("did:example:def567"),
-			ResolveValue: mockdiddoc.GetMockDIDDoc("did:example:def567"),
+	return &mockprovider.MockProvider{
+		Provider: &ariesmockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{},
+				mediator.Coordination:   &mockroute.MockMediatorSvc{},
+				issuecredsvc.Name:       &issuecredential.MockIssueCredentialSvc{},
+				presentproofsvc.Name:    &presentproof.MockPresentProofSvc{},
+				outofbandsvc.Name:       &mockoutofband.MockService{},
+			},
+			KMSValue:             &mockkms.KeyManager{ImportPrivateKeyErr: fmt.Errorf("error import priv key")},
+			CryptoValue:          &mockcrypto.Crypto{},
+			ServiceEndpointValue: "endpoint",
+			VDRegistryValue: &mockvdri.MockVDRegistry{
+				CreateValue:  mockdiddoc.GetMockDIDDoc("did:example:def567"),
+				ResolveValue: mockdiddoc.GetMockDIDDoc("did:example:def567"),
+			},
 		},
 	}
 }

--- a/pkg/restapi/rp/operation/operations.go
+++ b/pkg/restapi/rp/operation/operations.go
@@ -161,6 +161,7 @@ type AriesContextProvider interface {
 	Crypto() ariescrypto.Crypto
 	Service(id string) (interface{}, error)
 	ServiceEndpoint() string
+	Messenger() service.Messenger
 }
 
 // Storage config.

--- a/pkg/restapi/wallet/controller.go
+++ b/pkg/restapi/wallet/controller.go
@@ -1,0 +1,36 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package wallet
+
+import (
+	"github.com/trustbloc/edge-adapter/pkg/restapi/wallet/operation"
+)
+
+// New returns new controller instance.
+func New(config *operation.Config) (*Controller, error) {
+	var allHandlers []operation.Handler
+
+	walletBridge, err := operation.New(config)
+	if err != nil {
+		return nil, err
+	}
+
+	handlers := walletBridge.GetRESTHandlers()
+
+	allHandlers = append(allHandlers, handlers...)
+
+	return &Controller{handlers: allHandlers}, nil
+}
+
+// Controller contains handlers for controller.
+type Controller struct {
+	handlers []operation.Handler
+}
+
+// GetOperations returns all controller endpoints.
+func (c *Controller) GetOperations() []operation.Handler {
+	return c.handlers
+}

--- a/pkg/restapi/wallet/controller_test.go
+++ b/pkg/restapi/wallet/controller_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package wallet
+
+import (
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/messaging/msghandler"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
+	outofbandsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofband"
+	mocksvc "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/didexchange"
+	mockroute "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/mediator"
+	ariesmockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/stretchr/testify/require"
+
+	mockoutofband "github.com/trustbloc/edge-adapter/pkg/internal/mock/outofband"
+	mockprovider "github.com/trustbloc/edge-adapter/pkg/restapi/internal/mocks/provider"
+	"github.com/trustbloc/edge-adapter/pkg/restapi/wallet/operation"
+)
+
+func TestController_New(t *testing.T) {
+	t.Run("test success", func(t *testing.T) {
+		controller, err := New(&operation.Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue:              mockstore.NewMockStoreProvider(),
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					ServiceMap: map[string]interface{}{
+						didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{},
+						outofbandsvc.Name:       &mockoutofband.MockService{},
+						mediator.Coordination:   &mockroute.MockMediatorSvc{},
+					},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, controller)
+		ops := controller.GetOperations()
+
+		require.NotEmpty(t, ops)
+	})
+}

--- a/pkg/restapi/wallet/operation/models.go
+++ b/pkg/restapi/wallet/operation/models.go
@@ -1,0 +1,102 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// createInvitationRequest model
+//
+// Request for creating wallet server invitation.
+//
+// swagger:parameters createInvitation
+type createInvitationRequest struct {
+	// in: body
+	Body struct {
+		// required: true
+		UserID string `json:"userID"`
+	}
+}
+
+// createInvitationResponse model
+//
+//  Response of out-of-band invitation from wallet server.
+//
+// swagger:response createInvitationResponse
+type createInvitationResponse struct {
+	// in: body
+	URL string `json:"url"`
+}
+
+// applicationProfileRequest model
+//
+// Request for querying wallet application profile ID for given user from wallet server.
+//
+// swagger:parameters applicationProfileRequest
+type applicationProfileRequest struct {
+	// in: body
+	Body struct {
+		// UserID of wallet application profile.
+		// required: true
+		UserID string `json:"userID"`
+
+		// Wait for connection to be completed before returning wallet application profile.
+		// in: body
+		WaitForConnection bool `json:"waitForConnection"`
+
+		// Timeout (in nanoseconds) waiting for connection completed.
+		// in: body
+		Timeout time.Duration `json:"timeout"`
+	}
+}
+
+// applicationProfileResponse model
+//
+// Response containing wallet application profile of user requested.
+//
+// swagger:response appProfileResponse
+type applicationProfileResponse struct {
+	// InvitationID of invitation used to create profile.
+	// in: body
+	InvitationID string `json:"invitationID"`
+
+	// ConnectionStatus is DIDComm connection status of the profile.
+	// in: body
+	ConnectionStatus string `json:"status"`
+}
+
+// chapiRequest model
+//
+// CHAPI request to be sent to given wallet application.
+//
+// swagger:parameters chapiRequest
+type chapiRequest struct {
+	// required: true
+	// in: body
+	Body struct {
+		// UserID of wallet application profile.
+		UserID string `json:"userID"`
+		// Request is credential handler request to be sent out.
+		Request json.RawMessage `json:"chapiRequest"`
+		// Timeout (in nanoseconds) waiting for reply.
+		Timeout time.Duration `json:"timeout,omitempty"`
+	}
+}
+
+// chapiResponse model
+//
+// CHAPI response from requested wallet application.
+//
+// swagger:response chapiResponse
+type chapiResponse struct {
+	// in: body
+	Body struct {
+		Response json.RawMessage `json:"chapiResponse"`
+	}
+}

--- a/pkg/restapi/wallet/operation/operations.go
+++ b/pkg/restapi/wallet/operation/operations.go
@@ -1,0 +1,449 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package operation provides wallet adapter REST features.
+package operation
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
+	"github.com/hyperledger/aries-framework-go/pkg/client/messaging"
+	"github.com/hyperledger/aries-framework-go/pkg/client/outofband"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	didexchangesvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/edge-adapter/pkg/aries"
+	"github.com/trustbloc/edge-adapter/pkg/internal/common/support"
+	commhttp "github.com/trustbloc/edge-adapter/pkg/restapi/internal/common/http"
+)
+
+var logger = log.New("edge-adapter/wallet-bridge")
+
+// constants for endpoints of wallet bridge controller.
+const (
+	commandName          = "/wallet"
+	CreateInvitationPath = "/create-invitation"
+	RequestAppProfile    = "/request-app-profile"
+	SendCHAPIRequest     = "/send-chapi-request"
+
+	invalidIDErr                = "invalid ID"
+	invalidCHAPIRequestErr      = "invalid CHAPI request"
+	failedToSendCHAPIRequestErr = "failed to send CHAPI request: %s"
+	noConnectionFoundErr        = "failed to find connection with existing wallet profile"
+
+	chapiRqstDIDCommMsgType = "https://trustbloc.dev/chapi/1.0/request"
+	chapiRespDIDCommMsgType = "https://trustbloc.dev/chapi/1.0/response"
+
+	defaultSendMsgTimeout = 20 * time.Second
+)
+
+// Handler http handler for each controller API endpoint.
+type Handler interface {
+	Path() string
+	Method() string
+	Handle() http.HandlerFunc
+}
+
+// Operation is REST service operation controller for wallet bridge features.
+type Operation struct {
+	agentLabel   string
+	walletAppURL string
+	store        *walletAppProfileStore
+	outOfBand    *outofband.Client
+	didExchange  *didexchange.Client
+	messenger    *messaging.Client
+}
+
+// Config defines configuration for wallet adapter operations.
+type Config struct {
+	AriesCtx     aries.CtxProvider
+	MsgRegistrar command.MessageHandler
+	WalletAppURL string
+	DefaultLabel string
+}
+
+// New returns new wallet bridge REST controller instance.
+func New(config *Config) (*Operation, error) {
+	store, err := newWalletAppProfileStore(config.AriesCtx.StorageProvider())
+	if err != nil {
+		return nil, fmt.Errorf("failed to open wallet profile store : %w", err)
+	}
+
+	messengerClient, err := messaging.New(config.AriesCtx, config.MsgRegistrar, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create messenger client : %w", err)
+	}
+
+	outOfBandClient, err := outofband.New(config.AriesCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create out-of-band client : %w", err)
+	}
+
+	didExchangeClient, err := didexchange.New(config.AriesCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create did-exchange client : %w", err)
+	}
+
+	o := &Operation{
+		agentLabel:   config.DefaultLabel,
+		walletAppURL: config.WalletAppURL,
+		store:        store,
+		outOfBand:    outOfBandClient,
+		didExchange:  didExchangeClient,
+		messenger:    messengerClient,
+	}
+
+	err = o.setupEventHandlers()
+	if err != nil {
+		return nil, fmt.Errorf("failed to register events : %w", err)
+	}
+
+	return o, nil
+}
+
+// GetRESTHandlers get all controller API handler available for this protocol service.
+func (o *Operation) GetRESTHandlers() []Handler {
+	return []Handler{
+		support.NewHTTPHandler(CreateInvitationPath, http.MethodPost, o.CreateInvitation),
+		support.NewHTTPHandler(RequestAppProfile, http.MethodPost, o.RequestApplicationProfile),
+		support.NewHTTPHandler(SendCHAPIRequest, http.MethodPost, o.SendCHAPIRequest),
+	}
+}
+
+// CreateInvitation swagger:route POST /wallet/create-invitation wallet-bridge createInvitation
+//
+// Creates out-of-band invitation to connect to this wallet server.
+// Response contains URL to application with invitation to load during startup.
+//
+// Responses:
+//    default: genericError
+//    200: createInvitationResponse
+func (o *Operation) CreateInvitation(rw http.ResponseWriter, req *http.Request) {
+	var request createInvitationRequest
+
+	err := json.NewDecoder(req.Body).Decode(&request.Body)
+	if err != nil {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusBadRequest, err.Error(), CreateInvitationPath, logger)
+
+		return
+	}
+
+	if request.Body.UserID == "" {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusBadRequest, invalidIDErr, CreateInvitationPath, logger)
+
+		return
+	}
+
+	// TODO : public DIDs in request parameters - [Issue#edge-agent:645]
+	invitation, err := o.outOfBand.CreateInvitation([]string{didexchangesvc.PIURI},
+		outofband.WithLabel(o.agentLabel))
+	if err != nil {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusInternalServerError, err.Error(), CreateInvitationPath, logger)
+
+		return
+	}
+
+	invitationBytes, err := json.Marshal(invitation)
+	if err != nil {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusInternalServerError, err.Error(), CreateInvitationPath, logger)
+
+		return
+	}
+
+	err = o.store.SaveProfile(request.Body.UserID, &walletAppProfile{InvitationID: invitation.ID})
+	if err != nil {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusInternalServerError, err.Error(), CreateInvitationPath, logger)
+
+		return
+	}
+
+	rw.WriteHeader(http.StatusOK)
+	commhttp.WriteResponseWithLog(rw,
+		&createInvitationResponse{
+			URL: fmt.Sprintf("%s?oob=%s", o.walletAppURL, base64.StdEncoding.EncodeToString(invitationBytes)),
+		}, CreateInvitationPath, logger)
+}
+
+// RequestApplicationProfile swagger:route POST /wallet/request-app-profile wallet-bridge applicationProfileRequest
+//
+// Requests wallet application profile of given user.
+// Response contains wallet application profile of given user.
+//
+// Responses:
+//    default: genericError
+//    200: appProfileResponse
+func (o *Operation) RequestApplicationProfile(rw http.ResponseWriter, req *http.Request) {
+	request, err := prepareAppProfileRequest(req.Body)
+	if err != nil {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusBadRequest, err.Error(), RequestAppProfile, logger)
+
+		return
+	}
+
+	profile, err := o.store.GetProfileByUserID(request.Body.UserID)
+	if err != nil {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusInternalServerError, err.Error(), RequestAppProfile, logger)
+
+		return
+	}
+
+	// if status is not completed, then wait for completion if 'WaitForConnection=true'
+	var status string
+	if profile.ConnectionID != "" {
+		status = didexchangesvc.StateIDCompleted
+	} else if request.Body.WaitForConnection {
+		ctx, cancel := context.WithTimeout(context.Background(), request.Body.Timeout)
+		defer cancel()
+
+		err = o.waitForConnectionCompletion(ctx, profile)
+		if err != nil {
+			commhttp.WriteErrorResponseWithLog(rw, http.StatusInternalServerError, err.Error(), RequestAppProfile, logger)
+
+			return
+		}
+
+		status = didexchangesvc.StateIDCompleted
+	}
+
+	rw.WriteHeader(http.StatusOK)
+	commhttp.WriteResponseWithLog(rw,
+		&applicationProfileResponse{profile.InvitationID, status}, RequestAppProfile, logger)
+}
+
+// SendCHAPIRequest swagger:route POST /wallet/send-chapi-request wallet-bridge chapiRequest
+//
+// Sends CHAPI request to given wallet application ID.
+// Response contains CHAPI request.
+//
+// Responses:
+//    default: genericError
+//    200: chapiResponse
+func (o *Operation) SendCHAPIRequest(rw http.ResponseWriter, req *http.Request) {
+	request, err := prepareCHAPIRequest(req.Body)
+	if err != nil {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusBadRequest, err.Error(), SendCHAPIRequest, logger)
+
+		return
+	}
+
+	profile, err := o.store.GetProfileByUserID(request.Body.UserID)
+	if err != nil {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusBadRequest, err.Error(), SendCHAPIRequest, logger)
+
+		return
+	}
+
+	if profile.ConnectionID == "" {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusInternalServerError, noConnectionFoundErr, SendCHAPIRequest, logger)
+
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), request.Body.Timeout)
+	defer cancel()
+
+	msgBytes, err := json.Marshal(map[string]interface{}{
+		"@id":   uuid.New().String(),
+		"@type": chapiRqstDIDCommMsgType,
+		"data":  request.Body.Request,
+	})
+	if err != nil {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusInternalServerError, err.Error(), SendCHAPIRequest, logger)
+
+		return
+	}
+
+	responseBytes, err := o.messenger.Send(msgBytes,
+		messaging.SendByConnectionID(profile.ConnectionID),
+		messaging.WaitForResponse(ctx, chapiRespDIDCommMsgType))
+	if err != nil {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusInternalServerError,
+			fmt.Sprintf(failedToSendCHAPIRequestErr, err), SendCHAPIRequest, logger)
+
+		return
+	}
+
+	response, err := extractCHAPIResponse(responseBytes)
+	if err != nil {
+		commhttp.WriteErrorResponseWithLog(rw, http.StatusInternalServerError, err.Error(), SendCHAPIRequest, logger)
+
+		return
+	}
+
+	rw.WriteHeader(http.StatusOK)
+	commhttp.WriteResponseWithLog(rw, &chapiResponse{
+		Body: struct {
+			Response json.RawMessage `json:"chapiResponse"`
+		}{Response: response},
+	}, SendCHAPIRequest, logger)
+}
+
+func (o *Operation) setupEventHandlers() error {
+	// creates action channel
+	actions := make(chan service.DIDCommAction)
+	// registers action channel to listen for events
+	if err := o.didExchange.RegisterActionEvent(actions); err != nil {
+		return fmt.Errorf("register action event: %w", err)
+	}
+
+	// create state channel subscribers
+	states := make(chan service.StateMsg)
+
+	// registers state channels to listen for events
+	if err := o.didExchange.RegisterMsgEvent(states); err != nil {
+		return fmt.Errorf("register msg event: %w", err)
+	}
+
+	go service.AutoExecuteActionEvent(actions)
+	go o.stateMsgListener(states)
+
+	return nil
+}
+
+func (o *Operation) stateMsgListener(ch <-chan service.StateMsg) {
+	for msg := range ch {
+		if msg.Type != service.PostState || msg.StateID != didexchangesvc.StateIDCompleted {
+			continue
+		}
+
+		var event didexchange.Event
+
+		switch p := msg.Properties.(type) {
+		case didexchange.Event:
+			event = p
+		default:
+			logger.Warnf("failed to cast didexchange event properties")
+
+			continue
+		}
+
+		logger.Debugf(
+			"Received connection complete event for invitationID=%s connectionID=%s",
+			event.InvitationID(), event.ConnectionID())
+
+		// TODO update profile only wallet bridge didexchange, in this solution below warning will show up
+		// everytime during adapter didexchange completion.
+		err := o.store.UpdateProfile(&walletAppProfile{
+			InvitationID: event.InvitationID(),
+			ConnectionID: event.ConnectionID(),
+		})
+		if err != nil {
+			logger.Warnf("Failed to update wallet application profile: %w", err)
+		}
+	}
+}
+
+//nolint:gocyclo //can't split function further and maintain readability.
+func (o *Operation) waitForConnectionCompletion(ctx context.Context, profile *walletAppProfile) error {
+	stateCh := make(chan service.StateMsg)
+
+	if err := o.didExchange.RegisterMsgEvent(stateCh); err != nil {
+		return fmt.Errorf("register msg event: %w", err)
+	}
+
+	defer func() {
+		e := o.didExchange.UnregisterMsgEvent(stateCh)
+		if e != nil {
+			logger.Warnf("Failed to unregister msg event registered to wait for profile connection completion: %w", e)
+		}
+	}()
+
+	for {
+		select {
+		case msg := <-stateCh:
+			if msg.Type != service.PostState || msg.StateID != didexchangesvc.StateIDCompleted {
+				continue
+			}
+
+			var event didexchange.Event
+
+			switch p := msg.Properties.(type) {
+			case didexchange.Event:
+				event = p
+			default:
+				logger.Warnf("failed to cast didexchange event properties")
+
+				continue
+			}
+
+			if event.InvitationID() == profile.InvitationID {
+				logger.Debugf(
+					"Received connection complete event for invitationID=%s", event.InvitationID())
+
+				return nil
+			}
+		case <-ctx.Done():
+			return fmt.Errorf("time out waiting for state 'completed'")
+		}
+	}
+}
+
+func prepareAppProfileRequest(r io.Reader) (*applicationProfileRequest, error) {
+	var request applicationProfileRequest
+
+	err := json.NewDecoder(r).Decode(&request.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if request.Body.UserID == "" {
+		return nil, fmt.Errorf(invalidIDErr)
+	}
+
+	if request.Body.WaitForConnection && request.Body.Timeout == 0 {
+		request.Body.Timeout = defaultSendMsgTimeout
+	}
+
+	return &request, nil
+}
+
+func prepareCHAPIRequest(r io.Reader) (*chapiRequest, error) {
+	var request chapiRequest
+
+	err := json.NewDecoder(r).Decode(&request.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if request.Body.UserID == "" {
+		return nil, fmt.Errorf(invalidIDErr)
+	}
+
+	if len(request.Body.Request) == 0 {
+		return nil, fmt.Errorf(invalidCHAPIRequestErr)
+	}
+
+	if request.Body.Timeout == 0 {
+		request.Body.Timeout = defaultSendMsgTimeout
+	}
+
+	return &request, nil
+}
+
+func extractCHAPIResponse(msgBytes []byte) (json.RawMessage, error) {
+	var response struct {
+		Message struct {
+			Data json.RawMessage
+		}
+	}
+
+	err := json.Unmarshal(msgBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Message.Data, nil
+}

--- a/pkg/restapi/wallet/operation/operations_test.go
+++ b/pkg/restapi/wallet/operation/operations_test.go
@@ -1,0 +1,909 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation // nolint:testpackage // changing to different package requires exposing internal features.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/messaging/msghandler"
+	didexchangesvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
+	outofbandsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofband"
+	mockmsghandler "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/msghandler"
+	mockdidexsvc "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/didexchange"
+	mockroute "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/mediator"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
+	ariesmockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+	"github.com/stretchr/testify/require"
+
+	mockoutofband "github.com/trustbloc/edge-adapter/pkg/internal/mock/outofband"
+	mockprotocol "github.com/trustbloc/edge-adapter/pkg/restapi/internal/mocks/protocol"
+	mockprovider "github.com/trustbloc/edge-adapter/pkg/restapi/internal/mocks/provider"
+)
+
+const (
+	sampleAppURL = "http://demo.wallet.app/home"
+	sampleErr    = "sample-error"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("create new instance - success", func(t *testing.T) {
+		op, err := New(newMockConfig())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+		require.Len(t, op.GetRESTHandlers(), 3)
+	})
+
+	t.Run("create new instance - oob client failure", func(t *testing.T) {
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue:              mockstore.NewMockStoreProvider(),
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					ServiceMap: map[string]interface{}{
+						didexchangesvc.DIDExchange: &mockdidexsvc.MockDIDExchangeSvc{},
+						mediator.Coordination:      &mockroute.MockMediatorSvc{},
+					},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to create out-of-band client")
+		require.Empty(t, op)
+	})
+
+	t.Run("create new instance - did exchange client failure", func(t *testing.T) {
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue:              mockstore.NewMockStoreProvider(),
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					ServiceMap: map[string]interface{}{
+						outofbandsvc.Name:     &mockoutofband.MockService{},
+						mediator.Coordination: &mockroute.MockMediatorSvc{},
+					},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to create did-exchange client")
+		require.Empty(t, op)
+	})
+
+	t.Run("create new instance - open store failure", func(t *testing.T) {
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue: &mockstore.MockStoreProvider{
+						ErrOpenStoreHandle: fmt.Errorf(sampleErr),
+					},
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					ServiceMap: map[string]interface{}{
+						didexchangesvc.DIDExchange: &mockdidexsvc.MockDIDExchangeSvc{},
+						outofbandsvc.Name:          &mockoutofband.MockService{},
+						mediator.Coordination:      &mockroute.MockMediatorSvc{},
+					},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to open wallet profile store")
+		require.Contains(t, err.Error(), "sample-error")
+		require.Empty(t, op)
+	})
+
+	t.Run("create new instance - register action event failure", func(t *testing.T) {
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue:              mockstore.NewMockStoreProvider(),
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					ServiceMap: map[string]interface{}{
+						didexchangesvc.DIDExchange: &mockdidexsvc.MockDIDExchangeSvc{
+							RegisterActionEventErr: fmt.Errorf(sampleErr),
+						},
+						outofbandsvc.Name:     &mockoutofband.MockService{},
+						mediator.Coordination: &mockroute.MockMediatorSvc{},
+					},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+		})
+
+		require.Error(t, err)
+		require.Empty(t, op)
+		require.Contains(t, err.Error(), "failed to register events")
+	})
+
+	t.Run("create new instance - register state event failure", func(t *testing.T) {
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue:              mockstore.NewMockStoreProvider(),
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					ServiceMap: map[string]interface{}{
+						didexchangesvc.DIDExchange: &mockdidexsvc.MockDIDExchangeSvc{
+							RegisterMsgEventErr: fmt.Errorf(sampleErr),
+						},
+						outofbandsvc.Name:     &mockoutofband.MockService{},
+						mediator.Coordination: &mockroute.MockMediatorSvc{},
+					},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+		})
+
+		require.Error(t, err)
+		require.Empty(t, op)
+		require.Contains(t, err.Error(), "failed to register events")
+	})
+
+	t.Run("create new instance - init messenger failure", func(t *testing.T) {
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue: &mockstore.MockStoreProvider{
+						FailNamespace: "didexchange",
+					},
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					ServiceMap: map[string]interface{}{
+						didexchangesvc.DIDExchange: &mockdidexsvc.MockDIDExchangeSvc{},
+						outofbandsvc.Name:          &mockoutofband.MockService{},
+						mediator.Coordination:      &mockroute.MockMediatorSvc{},
+					},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+		})
+
+		require.Error(t, err)
+		require.Empty(t, op)
+		require.Contains(t, err.Error(), "failed to create messenger client")
+	})
+}
+
+func TestOperation_CreateInvitation(t *testing.T) {
+	const sampleRequest = `{"userID": "1234"}`
+
+	const sampleInvalidRequest = `{"userID": ""}`
+
+	t.Run("create new invitation - success", func(t *testing.T) {
+		op, err := New(newMockConfig())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodPost, commandName+CreateInvitationPath,
+			bytes.NewBufferString(sampleRequest))
+
+		op.CreateInvitation(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusOK)
+		require.Contains(t, rw.Body.String(), `{"url":"http://demo.wallet.app/home?oob=eyJAaWQiO`)
+	})
+
+	t.Run("create new invitation - failure - oob error", func(t *testing.T) {
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue:              mockstore.NewMockStoreProvider(),
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					KMSValue:                          &mockkms.KeyManager{},
+					ServiceMap: map[string]interface{}{
+						didexchangesvc.DIDExchange: &mockdidexsvc.MockDIDExchangeSvc{},
+						outofbandsvc.Name: &mockprotocol.MockOobService{
+							SaveInvitationErr: fmt.Errorf(sampleErr),
+						},
+						mediator.Coordination: &mockroute.MockMediatorSvc{},
+					},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+		})
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodPost, commandName+CreateInvitationPath,
+			bytes.NewBufferString(sampleRequest))
+
+		op.CreateInvitation(rw, rq)
+		require.Equal(t, rw.Code, http.StatusInternalServerError)
+
+		require.Contains(t, rw.Body.String(), `{"errMessage":"failed to save outofband invitation : sample-error"}`)
+	})
+
+	t.Run("create new invitation - failure - validation error", func(t *testing.T) {
+		op, err := New(newMockConfig())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodPost, commandName+CreateInvitationPath,
+			bytes.NewBufferString(sampleInvalidRequest))
+
+		op.CreateInvitation(rw, rq)
+		require.Equal(t, rw.Code, http.StatusBadRequest)
+
+		require.Contains(t, rw.Body.String(), invalidIDErr)
+	})
+
+	t.Run("create new invitation - failure - invalid request", func(t *testing.T) {
+		op, err := New(newMockConfig())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodPost, commandName+CreateInvitationPath,
+			bytes.NewBufferString("-----"))
+
+		op.CreateInvitation(rw, rq)
+		require.Equal(t, rw.Code, http.StatusBadRequest)
+
+		require.Contains(t, rw.Body.String(), "invalid character")
+	})
+
+	t.Run("create new invitation - failure - save profile error", func(t *testing.T) {
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue: &mockstore.MockStoreProvider{
+						Store: &mockstore.MockStore{
+							ErrPut: fmt.Errorf(sampleErr),
+						},
+					},
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					KMSValue:                          &mockkms.KeyManager{},
+					ServiceMap: map[string]interface{}{
+						didexchangesvc.DIDExchange: &mockdidexsvc.MockDIDExchangeSvc{},
+						outofbandsvc.Name:          &mockoutofband.MockService{},
+						mediator.Coordination:      &mockroute.MockMediatorSvc{},
+					},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+			WalletAppURL: sampleAppURL,
+		})
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodPost, commandName+CreateInvitationPath,
+			bytes.NewBufferString(sampleRequest))
+
+		op.CreateInvitation(rw, rq)
+		require.Equal(t, rw.Code, http.StatusInternalServerError)
+
+		require.Contains(t, rw.Body.String(), `{"errMessage":"failed to save wallet application profile: sample-error"}`)
+	})
+}
+
+func TestOperation_RequestApplicationProfile(t *testing.T) {
+	sampleReq := fmt.Sprintf(`{"userID":"%s"}`, sampleUserID)
+	sampleReq2 := fmt.Sprintf(`{"userID":"%s", "waitForConnection":true, "timeout":1}`, sampleUserID)
+	sampleReq3 := `{"userID":"invalid-001", "waitForConnection":true}`
+
+	t.Run("create application profile - success", func(t *testing.T) {
+		op, err := New(newMockConfig())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		sampleProfile := &walletAppProfile{InvitationID: sampleInvID, ConnectionID: sampleConnID}
+		err = op.store.SaveProfile(sampleUserID, sampleProfile)
+		require.NoError(t, err)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodGet, commandName+RequestAppProfile, bytes.NewBufferString(sampleReq))
+
+		op.RequestApplicationProfile(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusOK)
+
+		response := applicationProfileResponse{}
+		err = json.Unmarshal(rw.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.Equal(t, response.InvitationID, sampleProfile.InvitationID)
+		require.Equal(t, response.ConnectionStatus, didexchangesvc.StateIDCompleted)
+	})
+
+	t.Run("create application profile - success but status not completed", func(t *testing.T) {
+		op, err := New(newMockConfig())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		sampleProfile := &walletAppProfile{InvitationID: sampleInvID}
+		err = op.store.SaveProfile(sampleUserID, sampleProfile)
+		require.NoError(t, err)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodGet, commandName+RequestAppProfile, bytes.NewBufferString(sampleReq))
+		rq = mux.SetURLVars(rq, map[string]string{
+			"id": sampleUserID,
+		})
+
+		op.RequestApplicationProfile(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusOK)
+
+		response := applicationProfileResponse{}
+		err = json.Unmarshal(rw.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.Equal(t, response.InvitationID, sampleProfile.InvitationID)
+		require.Empty(t, response.ConnectionStatus)
+	})
+
+	t.Run("create application profile - invalid request", func(t *testing.T) {
+		op, err := New(newMockConfig())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		sampleProfile := &walletAppProfile{InvitationID: sampleInvID, ConnectionID: sampleConnID}
+		err = op.store.SaveProfile(sampleUserID, sampleProfile)
+		require.NoError(t, err)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodGet, commandName+RequestAppProfile, bytes.NewBufferString(`{}`))
+
+		op.RequestApplicationProfile(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusBadRequest)
+		require.Contains(t, rw.Body.String(), invalidIDErr)
+
+		rw = httptest.NewRecorder()
+		rq = httptest.NewRequest(http.MethodGet, commandName+RequestAppProfile, bytes.NewBufferString(`===`))
+
+		op.RequestApplicationProfile(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusBadRequest)
+		require.Contains(t, rw.Body.String(), "invalid character")
+	})
+
+	t.Run("create application profile - profile not found", func(t *testing.T) {
+		op, err := New(newMockConfig())
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodGet, commandName+RequestAppProfile, bytes.NewBufferString(sampleReq3))
+		rq = mux.SetURLVars(rq, map[string]string{
+			"id": sampleUserID,
+		})
+
+		op.RequestApplicationProfile(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Contains(t, rw.Body.String(), "failed to get wallet application profile by user ID: data not found")
+	})
+
+	t.Run("test didexchange completed", func(t *testing.T) {
+		op, err := New(newMockConfig())
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		sampleProfile := &walletAppProfile{InvitationID: sampleInvID}
+		err = op.store.SaveProfile(sampleUserID, sampleProfile)
+		require.NoError(t, err)
+
+		ch := make(chan service.StateMsg)
+
+		go op.stateMsgListener(ch)
+
+		ch <- service.StateMsg{
+			Type:    service.PostState,
+			StateID: didexchangesvc.StateIDCompleted,
+			Properties: &mockdidexsvc.MockEventProperties{
+				InvID:  sampleInvID,
+				ConnID: sampleConnID,
+			},
+		}
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodGet, commandName+RequestAppProfile, bytes.NewBufferString(sampleReq))
+		rq = mux.SetURLVars(rq, map[string]string{
+			"id": sampleUserID,
+		})
+
+		op.RequestApplicationProfile(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusOK)
+
+		response := applicationProfileResponse{}
+		err = json.Unmarshal(rw.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.Equal(t, response.InvitationID, sampleProfile.InvitationID)
+		require.Equal(t, response.ConnectionStatus, didexchangesvc.StateIDCompleted)
+	})
+
+	t.Run("test didexchange completed - but update profile failed", func(t *testing.T) {
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue: &mockstore.MockStoreProvider{
+						Store: &mockstore.MockStore{
+							ErrPut: fmt.Errorf(sampleErr),
+						},
+					},
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					KMSValue:                          &mockkms.KeyManager{},
+					ServiceMap: map[string]interface{}{
+						didexchangesvc.DIDExchange: &mockdidexsvc.MockDIDExchangeSvc{},
+						outofbandsvc.Name:          &mockoutofband.MockService{},
+						mediator.Coordination:      &mockroute.MockMediatorSvc{},
+					},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+			WalletAppURL: sampleAppURL,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		ch := make(chan service.StateMsg)
+
+		go op.stateMsgListener(ch)
+
+		ch <- service.StateMsg{
+			Type:    service.PostState,
+			StateID: didexchangesvc.StateIDCompleted,
+			Properties: &mockdidexsvc.MockEventProperties{
+				InvID:  sampleInvID,
+				ConnID: sampleConnID,
+			},
+		}
+
+		profile, err := op.store.GetProfileByUserID(sampleUserID)
+		require.Error(t, err)
+		require.Empty(t, profile)
+	})
+
+	t.Run("test didexchange not completed", func(t *testing.T) {
+		op, err := New(newMockConfig())
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		sampleProfile := &walletAppProfile{InvitationID: sampleInvID}
+		err = op.store.SaveProfile(sampleUserID, sampleProfile)
+		require.NoError(t, err)
+
+		ch := make(chan service.StateMsg)
+
+		go op.stateMsgListener(ch)
+
+		ch <- service.StateMsg{
+			Type:    service.PostState,
+			StateID: didexchangesvc.StateIDCompleted,
+		}
+
+		ch <- service.StateMsg{
+			Type:    service.PostState,
+			StateID: didexchangesvc.StateIDRequested,
+			Properties: &mockdidexsvc.MockEventProperties{
+				InvID:  sampleInvID,
+				ConnID: sampleConnID,
+			},
+		}
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodGet, commandName+RequestAppProfile, bytes.NewBufferString(sampleReq))
+		rq = mux.SetURLVars(rq, map[string]string{
+			"id": sampleUserID,
+		})
+
+		op.RequestApplicationProfile(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusOK)
+
+		response := applicationProfileResponse{}
+		err = json.Unmarshal(rw.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.Equal(t, response.InvitationID, sampleProfile.InvitationID)
+		require.Empty(t, response.ConnectionStatus)
+	})
+
+	t.Run("create application profile - failure wait for completion", func(t *testing.T) {
+		op, err := New(newMockConfig())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		sampleProfile := &walletAppProfile{InvitationID: sampleInvID}
+		err = op.store.SaveProfile(sampleUserID, sampleProfile)
+		require.NoError(t, err)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodGet, commandName+RequestAppProfile, bytes.NewBufferString(sampleReq2))
+
+		op.RequestApplicationProfile(rw, rq)
+		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Contains(t, rw.Body.String(), "time out waiting for state 'completed'")
+	})
+}
+
+func TestOperation_SendCHAPIRequest(t *testing.T) {
+	const chapiRequestSample = `{
+			"userID": "userID-001",
+			"chapiRequest" : {
+				"web": {
+        			"VerifiablePresentation": {
+            			"query": {
+                			"type": "DIDAuth"
+            			}
+        			}
+    			}
+			}
+		}`
+
+	const chapiResponseSample = `{
+  	"@context": [
+    	"https://www.w3.org/2018/credentials/v1"
+  	],
+  	"holder": "did:trustbloc:4vSjd:EiCpyXBU6bBluyIBkDGLFEIJ5wqqfcSIXgqSLSV19f-e2g",
+  	"proof": {
+    		"challenge": "487c6f9b-b2c5-4c64-be01-eac663797ea9",
+    		"created": "2021-01-21T17:56:35.838-05:00",
+    		"domain": "example.com",
+    		"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiLMNik59d8p4MsdpaBA",
+			"proofPurpose": "authentication",
+    		"type": "Ed25519Signature2018",
+    		"verificationMethod": "did:trustbloc:4vSjd:EiCpyXBU6bBluyIBk1HM"
+		},
+	"type": "VerifiablePresentation"
+	}`
+
+	const responseMsg = `
+						{
+							"@id": "EiCpyXBU6bBluy",
+							"@type": "%s",
+							"data": %s,
+							"~thread" : {"thid": "%s"}
+						}
+					`
+
+	t.Run("test send CHAPI request - validation errors", func(t *testing.T) {
+		op, err := New(newMockConfig())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		// test missing user ID
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodPost, commandName+SendCHAPIRequest, bytes.NewBufferString(`{}`))
+		op.SendCHAPIRequest(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusBadRequest)
+		require.Contains(t, rw.Body.String(), invalidIDErr)
+
+		// test missing CHAPI request
+		rw = httptest.NewRecorder()
+		rq = httptest.NewRequest(http.MethodPost, commandName+SendCHAPIRequest, bytes.NewBufferString(`{
+			"userID": "sample-001"
+		}`))
+		op.SendCHAPIRequest(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusBadRequest)
+		require.Contains(t, rw.Body.String(), invalidCHAPIRequestErr)
+
+		// test invalid request
+		rw = httptest.NewRecorder()
+		rq = httptest.NewRequest(http.MethodPost, commandName+SendCHAPIRequest, bytes.NewBufferString(`---`))
+		op.SendCHAPIRequest(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusBadRequest)
+		require.Contains(t, rw.Body.String(), "invalid character")
+	})
+
+	t.Run("test send CHAPI request - missing profile", func(t *testing.T) {
+		op, err := New(newMockConfig())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodPost, commandName+SendCHAPIRequest, bytes.NewBufferString(chapiRequestSample))
+		op.SendCHAPIRequest(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusBadRequest)
+		require.Contains(t, rw.Body.String(), "failed to get wallet application profile by user ID")
+	})
+
+	t.Run("test send CHAPI request - connection not found", func(t *testing.T) {
+		op, err := New(newMockConfig())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		err = op.store.SaveProfile(sampleUserID, &walletAppProfile{InvitationID: sampleInvID})
+		require.NoError(t, err)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodPost, commandName+SendCHAPIRequest, bytes.NewBufferString(chapiRequestSample))
+		op.SendCHAPIRequest(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Contains(t, rw.Body.String(), "failed to find connection with existing wallet profile")
+	})
+
+	t.Run("test send CHAPI request - message send error", func(t *testing.T) {
+		op, err := New(newMockConfig())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		err = op.store.SaveProfile(sampleUserID, &walletAppProfile{InvitationID: sampleInvID, ConnectionID: sampleConnID})
+		require.NoError(t, err)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodPost, commandName+SendCHAPIRequest, bytes.NewBufferString(chapiRequestSample))
+		op.SendCHAPIRequest(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Contains(t, rw.Body.String(), fmt.Sprintf(failedToSendCHAPIRequestErr, "data not found"))
+	})
+
+	t.Run("test send CHAPI request - success", func(t *testing.T) {
+		connBytes, err := json.Marshal(&connection.Record{
+			ConnectionID: sampleConnID,
+			State:        "completed", MyDID: "mydid", TheirDID: "theirDID-001",
+		})
+		require.NoError(t, err)
+
+		mockStore := &mockstore.MockStore{Store: make(map[string][]byte)}
+		require.NoError(t, mockStore.Put("conn_"+sampleConnID, connBytes))
+
+		registrar := mockmsghandler.NewMockMsgServiceProvider()
+		mockMessenger := mockprovider.NewMockMessenger()
+
+		go func() {
+			for {
+				if len(registrar.Services()) > 0 && mockMessenger.GetLastID() != "" { //nolint: gocritic
+					replyMsg, e := service.ParseDIDCommMsgMap([]byte(
+						fmt.Sprintf(responseMsg, chapiRespDIDCommMsgType, chapiResponseSample, mockMessenger.GetLastID()),
+					))
+					require.NoError(t, e)
+
+					_, e = registrar.Services()[0].HandleInbound(replyMsg, "sampleDID", "sampleTheirDID")
+					require.NoError(t, e)
+
+					break
+				}
+			}
+		}()
+
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue:              mockstore.NewCustomMockStoreProvider(mockStore),
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					ServiceMap: map[string]interface{}{
+						didexchangesvc.DIDExchange: &mockdidexsvc.MockDIDExchangeSvc{},
+						outofbandsvc.Name:          &mockoutofband.MockService{},
+						mediator.Coordination:      &mockroute.MockMediatorSvc{},
+					},
+					KMSValue: &mockkms.KeyManager{},
+				},
+				CustomMessenger: mockMessenger,
+			},
+			MsgRegistrar: registrar,
+			WalletAppURL: sampleAppURL,
+		})
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		err = op.store.SaveProfile(sampleUserID, &walletAppProfile{InvitationID: sampleInvID, ConnectionID: sampleConnID})
+		require.NoError(t, err)
+
+		rw := httptest.NewRecorder()
+		rq := httptest.NewRequest(http.MethodPost, commandName+SendCHAPIRequest, bytes.NewBufferString(`{
+			"userID": "userID-001",
+			"chapiRequest" : {
+				"web": {
+        			"VerifiablePresentation": {
+            			"query": {
+                			"type": "DIDAuth"
+            			}
+        			}
+    			}
+			}
+		}`))
+		op.SendCHAPIRequest(rw, rq)
+
+		require.Equal(t, rw.Code, http.StatusOK)
+
+		var response chapiResponse
+		require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &response))
+		require.JSONEq(t, string(response.Body.Response), chapiResponseSample, "")
+	})
+}
+
+func TestOperation_WaitForStateCompletion(t *testing.T) {
+	t.Run("test wait for state completion - success", func(t *testing.T) {
+		mockDIDExSvc := &mockDIDExchangeSvc{MockDIDExchangeSvc: &mockdidexsvc.MockDIDExchangeSvc{}}
+
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue:              mockstore.NewMockStoreProvider(),
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					ServiceMap: map[string]interface{}{
+						didexchangesvc.DIDExchange: mockDIDExSvc,
+						outofbandsvc.Name:          &mockoutofband.MockService{},
+						mediator.Coordination:      &mockroute.MockMediatorSvc{},
+					},
+					KMSValue: &mockkms.KeyManager{},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+			WalletAppURL: sampleAppURL,
+		})
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		go func() {
+			for {
+				mockDIDExSvc.pushEvent(service.StateMsg{
+					Type:    service.PostState,
+					StateID: didexchangesvc.StateIDRequested,
+					Properties: &mockdidexsvc.MockEventProperties{
+						InvID:  sampleInvID,
+						ConnID: sampleConnID,
+					},
+				}, 1)
+
+				mockDIDExSvc.pushEvent(service.StateMsg{
+					Type:    service.PostState,
+					StateID: didexchangesvc.StateIDCompleted,
+					Properties: &mockdidexsvc.MockEventProperties{
+						InvID:  sampleInvID,
+						ConnID: sampleConnID,
+					},
+				}, 1)
+			}
+		}()
+
+		err = op.waitForConnectionCompletion(ctx, &walletAppProfile{InvitationID: sampleInvID})
+		require.NoError(t, err)
+	})
+
+	t.Run("test wait for state completion - timeout error & unregister error", func(t *testing.T) {
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue:              mockstore.NewMockStoreProvider(),
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					ServiceMap: map[string]interface{}{
+						didexchangesvc.DIDExchange: &mockdidexsvc.MockDIDExchangeSvc{
+							UnregisterMsgEventErr: fmt.Errorf(sampleErr),
+						},
+						outofbandsvc.Name:     &mockoutofband.MockService{},
+						mediator.Coordination: &mockroute.MockMediatorSvc{},
+					},
+					KMSValue: &mockkms.KeyManager{},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+			WalletAppURL: sampleAppURL,
+		})
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+		defer cancel()
+
+		err = op.waitForConnectionCompletion(ctx, &walletAppProfile{InvitationID: sampleInvID})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "time out waiting for state 'completed'")
+	})
+
+	t.Run("test wait for state completion - register msg event error", func(t *testing.T) {
+		mockDIDExSvc := &mockdidexsvc.MockDIDExchangeSvc{}
+
+		op, err := New(&Config{
+			AriesCtx: &mockprovider.MockProvider{
+				Provider: &ariesmockprovider.Provider{
+					StorageProviderValue:              mockstore.NewMockStoreProvider(),
+					ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+					ServiceMap: map[string]interface{}{
+						didexchangesvc.DIDExchange: mockDIDExSvc,
+						outofbandsvc.Name:          &mockoutofband.MockService{},
+						mediator.Coordination:      &mockroute.MockMediatorSvc{},
+					},
+					KMSValue: &mockkms.KeyManager{},
+				},
+			},
+			MsgRegistrar: msghandler.NewRegistrar(),
+			WalletAppURL: sampleAppURL,
+		})
+
+		require.NoError(t, err)
+		require.NotEmpty(t, op)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+		defer cancel()
+
+		mockDIDExSvc.RegisterMsgEventErr = fmt.Errorf(sampleErr)
+
+		err = op.waitForConnectionCompletion(ctx, &walletAppProfile{InvitationID: sampleInvID})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), sampleErr)
+	})
+}
+
+func newMockConfig() *Config {
+	return &Config{
+		AriesCtx: &mockprovider.MockProvider{
+			Provider: &ariesmockprovider.Provider{
+				StorageProviderValue:              mockstore.NewMockStoreProvider(),
+				ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+				ServiceMap: map[string]interface{}{
+					didexchangesvc.DIDExchange: &mockdidexsvc.MockDIDExchangeSvc{},
+					outofbandsvc.Name:          &mockoutofband.MockService{},
+					mediator.Coordination:      &mockroute.MockMediatorSvc{},
+				},
+				KMSValue: &mockkms.KeyManager{},
+			},
+		},
+		MsgRegistrar: msghandler.NewRegistrar(),
+		WalletAppURL: sampleAppURL,
+	}
+}
+
+type mockDIDExchangeSvc struct {
+	*mockdidexsvc.MockDIDExchangeSvc
+	lock   sync.RWMutex
+	events []chan<- service.StateMsg
+}
+
+func (m *mockDIDExchangeSvc) RegisterMsgEvent(ch chan<- service.StateMsg) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.events = append(m.events, ch)
+
+	return nil
+}
+
+func (m *mockDIDExchangeSvc) pushEvent(msg service.StateMsg, index int) {
+	fmt.Println("GOT EVENT")
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if index < len(m.events) {
+		m.events[index] <- msg
+	}
+}

--- a/pkg/restapi/wallet/operation/store.go
+++ b/pkg/restapi/wallet/operation/store.go
@@ -1,0 +1,122 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+const (
+	storageNamespace = "walletappprofile"
+	invitationKeyFmt = "inv_%s"
+	userIDKeyFmt     = "usr_%s"
+)
+
+// walletAppProfile is wallet application profile.
+type walletAppProfile struct {
+	InvitationID string `json:"invitationID"`
+	ConnectionID string `json:"connectionID"`
+}
+
+// walletAppProfileStore is wallet application profile store.
+type walletAppProfileStore struct {
+	store storage.Store
+}
+
+func newWalletAppProfileStore(p storage.Provider) (*walletAppProfileStore, error) {
+	store, err := p.OpenStore(storageNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open wallet applcation profile store: %w", err)
+	}
+
+	return &walletAppProfileStore{store}, nil
+}
+
+// SaveUserProfile saves wallet app profile by user ID.
+// Due to very frequent get wallet profile by user ID call data model will be saved in below format.
+// UserID --> WalletAppProfile{} & InvitationID --> UserID.
+// For now, Invitation will have one-to-one relationship with User Profile.
+func (w *walletAppProfileStore) SaveProfile(userID string, profile *walletAppProfile) error {
+	err := w.putProfileInStore(getUserIDKeyPrefix, userID, profile)
+	if err != nil {
+		return fmt.Errorf("failed to save wallet application profile: %w", err)
+	}
+
+	err = w.store.Put(getInvitationKeyPrefix(profile.InvitationID), []byte(userID))
+	if err != nil {
+		return fmt.Errorf("failed to save wallet application profile: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateProfile updates wallet app profile in underlying store.
+// returns error if no existing mapping found with any user profile.
+func (w *walletAppProfileStore) UpdateProfile(profile *walletAppProfile) error {
+	userIDBytes, err := w.store.Get(getInvitationKeyPrefix(profile.InvitationID))
+	if err != nil {
+		return fmt.Errorf("failed to get user profile for given wallet profile from store: %w", err)
+	}
+
+	err = w.putProfileInStore(getUserIDKeyPrefix, string(userIDBytes), profile)
+	if err != nil {
+		return fmt.Errorf("failed to update wallet application profile in store: %w", err)
+	}
+
+	return nil
+}
+
+// GetProfileByInvitationID returns wallet application profile by given invitation ID
+// returns error if no existing mapping found with any user profile.
+func (w *walletAppProfileStore) GetProfileByInvitationID(invitationID string) (*walletAppProfile, error) {
+	userIDBytes, err := w.store.Get(getInvitationKeyPrefix(invitationID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user profile for given invitationID: %w", err)
+	}
+
+	return w.GetProfileByUserID(string(userIDBytes))
+}
+
+// GetProfileByUserID returns wallet application profile by given user profile ID.
+// returns error if no existing mapping found with any user profile.
+func (w *walletAppProfileStore) GetProfileByUserID(userID string) (*walletAppProfile, error) {
+	profileBytes, err := w.store.Get(getUserIDKeyPrefix(userID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get wallet application profile by user ID: %w", err)
+	}
+
+	var profile walletAppProfile
+
+	err = json.Unmarshal(profileBytes, &profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get wallet application profile bytes: %w", err)
+	}
+
+	return &profile, nil
+}
+
+func (w *walletAppProfileStore) putProfileInStore(prefix func(string) string, key string, profile interface{}) error {
+	profileBytes, err := json.Marshal(profile)
+	if err != nil {
+		return fmt.Errorf("failed to get wallet application profile bytes: %w", err)
+	}
+
+	return w.store.Put(prefix(key), profileBytes)
+}
+
+// getInvitationKeyPrefix is key prefix for wallet application profile invitation key.
+func getInvitationKeyPrefix(invitationID string) string {
+	return fmt.Sprintf(invitationKeyFmt, invitationID)
+}
+
+// getUserIDKeyPrefix is key prefix for wallet application profile user ID key.
+func getUserIDKeyPrefix(userID string) string {
+	return fmt.Sprintf(userIDKeyFmt, userID)
+}

--- a/pkg/restapi/wallet/operation/store_test.go
+++ b/pkg/restapi/wallet/operation/store_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation // nolint:testpackage // changing to different package requires exposing internal features.
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	sampleStoreErr = "sample error"
+	sampleUserID   = "userID-001"
+	sampleInvID    = "invID-001"
+	sampleConnID   = "connID-001"
+)
+
+func TestNewWalletAppProfileStore(t *testing.T) {
+	t.Run("create new wallet app profile store - success", func(t *testing.T) {
+		store, err := newWalletAppProfileStore(&mockstorage.MockStoreProvider{})
+
+		require.NoError(t, err)
+		require.NotEmpty(t, store)
+	})
+
+	t.Run("create new wallet app profile store - failure", func(t *testing.T) {
+		store, err := newWalletAppProfileStore(&mockstorage.MockStoreProvider{
+			ErrOpenStoreHandle: fmt.Errorf(sampleStoreErr),
+		})
+
+		require.Error(t, err)
+		require.Empty(t, store)
+		require.Contains(t, err.Error(), "sample error")
+	})
+}
+
+func TestWalletAppProfileStore_SaveProfile(t *testing.T) {
+	t.Run("save wallet app profile - success", func(t *testing.T) {
+		appProfileStore, err := newWalletAppProfileStore(mockstorage.NewMockStoreProvider())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, appProfileStore)
+
+		err = appProfileStore.SaveProfile(sampleUserID, &walletAppProfile{InvitationID: sampleInvID})
+		require.NoError(t, err)
+
+		userIDBytes, err := appProfileStore.store.Get(getInvitationKeyPrefix(sampleInvID))
+		require.NoError(t, err)
+		require.Equal(t, string(userIDBytes), sampleUserID)
+
+		profileIDBytes, err := appProfileStore.store.Get(getUserIDKeyPrefix(sampleUserID))
+		require.NoError(t, err)
+
+		var profile walletAppProfile
+		err = json.Unmarshal(profileIDBytes, &profile)
+		require.NoError(t, err)
+		require.Equal(t, profile.InvitationID, sampleInvID)
+	})
+
+	t.Run("save wallet app profile - failure", func(t *testing.T) {
+		provider := mockstorage.NewMockStoreProvider()
+		provider.Store = &mockstorage.MockStore{
+			ErrPut: fmt.Errorf(sampleStoreErr),
+		}
+
+		appProfileStore, err := newWalletAppProfileStore(provider)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, appProfileStore)
+
+		err = appProfileStore.SaveProfile(sampleUserID, &walletAppProfile{InvitationID: sampleInvID})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), sampleStoreErr)
+	})
+}
+
+func TestWalletAppProfileStore_UpdateProfile(t *testing.T) {
+	t.Run("update wallet app profile - success", func(t *testing.T) {
+		appProfileStore, err := newWalletAppProfileStore(mockstorage.NewMockStoreProvider())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, appProfileStore)
+
+		err = appProfileStore.SaveProfile(sampleUserID, &walletAppProfile{InvitationID: sampleInvID})
+		require.NoError(t, err)
+
+		err = appProfileStore.UpdateProfile(&walletAppProfile{
+			InvitationID: sampleInvID,
+			ConnectionID: sampleConnID,
+		})
+		require.NoError(t, err)
+
+		userIDBytes, err := appProfileStore.store.Get(getInvitationKeyPrefix(sampleInvID))
+		require.NoError(t, err)
+		require.Equal(t, string(userIDBytes), sampleUserID)
+
+		profileIDBytes, err := appProfileStore.store.Get(getUserIDKeyPrefix(sampleUserID))
+		require.NoError(t, err)
+
+		var profile walletAppProfile
+		err = json.Unmarshal(profileIDBytes, &profile)
+		require.NoError(t, err)
+		require.Equal(t, profile.InvitationID, sampleInvID)
+		require.Equal(t, profile.ConnectionID, sampleConnID)
+	})
+
+	t.Run("update wallet app profile - failure - user profile missing", func(t *testing.T) {
+		appProfileStore, err := newWalletAppProfileStore(mockstorage.NewMockStoreProvider())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, appProfileStore)
+
+		err = appProfileStore.UpdateProfile(&walletAppProfile{
+			InvitationID: sampleInvID,
+			ConnectionID: sampleConnID,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get user profile for given wallet profile")
+	})
+
+	t.Run("update wallet app profile - failure - store error", func(t *testing.T) {
+		provider := mockstorage.NewMockStoreProvider()
+		provider.Store = &mockstorage.MockStore{
+			ErrPut: fmt.Errorf(sampleStoreErr),
+			Store: map[string][]byte{
+				getInvitationKeyPrefix(sampleInvID): []byte(sampleUserID),
+			},
+		}
+
+		appProfileStore, err := newWalletAppProfileStore(provider)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, appProfileStore)
+
+		err = appProfileStore.UpdateProfile(&walletAppProfile{
+			InvitationID: sampleInvID,
+			ConnectionID: sampleConnID,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), sampleStoreErr)
+		require.Contains(t, err.Error(), "failed to update wallet application profile in store")
+	})
+}
+
+func TestWalletAppProfileStore_Get(t *testing.T) {
+	t.Run("get wallet app profile - success", func(t *testing.T) {
+		appProfileStore, err := newWalletAppProfileStore(mockstorage.NewMockStoreProvider())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, appProfileStore)
+
+		storedProfile := &walletAppProfile{InvitationID: sampleInvID}
+		err = appProfileStore.SaveProfile(sampleUserID, storedProfile)
+		require.NoError(t, err)
+
+		profile, err := appProfileStore.GetProfileByUserID(sampleUserID)
+		require.NoError(t, err)
+		require.Equal(t, profile, storedProfile)
+
+		profile, err = appProfileStore.GetProfileByInvitationID(sampleInvID)
+		require.NoError(t, err)
+		require.Equal(t, profile, storedProfile)
+
+		storedProfile.ConnectionID = sampleConnID
+		err = appProfileStore.UpdateProfile(storedProfile)
+		require.NoError(t, err)
+
+		profile, err = appProfileStore.GetProfileByUserID(sampleUserID)
+		require.NoError(t, err)
+		require.Equal(t, profile, storedProfile)
+
+		profile, err = appProfileStore.GetProfileByInvitationID(sampleInvID)
+		require.NoError(t, err)
+		require.Equal(t, profile, storedProfile)
+	})
+
+	t.Run("get wallet app profile  - failure - store error", func(t *testing.T) {
+		provider := mockstorage.NewMockStoreProvider()
+		provider.Store = &mockstorage.MockStore{
+			ErrGet: fmt.Errorf(sampleStoreErr),
+		}
+
+		appProfileStore, err := newWalletAppProfileStore(provider)
+		require.NoError(t, err)
+
+		profile, err := appProfileStore.GetProfileByUserID(sampleUserID)
+		require.Error(t, err)
+		require.Empty(t, profile)
+		require.Contains(t, err.Error(), sampleStoreErr)
+
+		profile, err = appProfileStore.GetProfileByInvitationID(sampleInvID)
+		require.Error(t, err)
+		require.Empty(t, profile)
+		require.Contains(t, err.Error(), sampleStoreErr)
+	})
+
+	t.Run("get wallet app profile  - failure - invalid data", func(t *testing.T) {
+		provider := mockstorage.NewMockStoreProvider()
+		provider.Store = &mockstorage.MockStore{
+			Store: map[string][]byte{
+				getUserIDKeyPrefix(sampleUserID): []byte("--"),
+			},
+		}
+
+		appProfileStore, err := newWalletAppProfileStore(provider)
+		require.NoError(t, err)
+
+		profile, err := appProfileStore.GetProfileByUserID(sampleUserID)
+		require.Error(t, err)
+		require.Empty(t, profile)
+		require.Contains(t, err.Error(), "failed to get wallet application profile bytes")
+	})
+}
+
+func TestWalletAppProfileStore_putProfileInStore(t *testing.T) {
+	t.Run("get wallet app profile  - failure - invalid data", func(t *testing.T) {
+		appProfileStore, err := newWalletAppProfileStore(mockstorage.NewMockStoreProvider())
+		require.NoError(t, err)
+
+		err = appProfileStore.putProfileInStore(getUserIDKeyPrefix, sampleUserID, make(chan int))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get wallet application profile bytes")
+	})
+}


### PR DESCRIPTION
- migrated from
https://github.com/trustbloc/edge-agent/tree/main/pkg/restapi/wallet/chapibridge
- part of #413
- part of https://github.com/trustbloc/edge-agent/issues/651

- TODO: to be part of cmd/adapter-rest in next PR

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>