### PR TITLE
fix: issue governance credential as final step of profile creation

### DIFF
--- a/test/bdd/fixtures/adapter-rest/docker-compose.yml
+++ b/test/bdd/fixtures/adapter-rest/docker-compose.yml
@@ -96,7 +96,6 @@ services:
     networks:
       - bdd_net
 
-  # TODO: figure out how to make dynamic client registration endpoint be included in openid-configuration
   issuer-hydra.trustbloc.local:
     container_name: issuer-hydra.trustbloc.local
     image: oryd/hydra:v1.3.2-alpine


### PR DESCRIPTION
Governance credential issuance will fail if retried for a profile,
so it needs to be done last so a subsequent failure won't cause
the profile creation to deadlock.

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>