### PR TITLE
chore: Verifier profile -  Add supportsWACI configuration

### DIFF
--- a/pkg/db/rp/models.go
+++ b/pkg/db/rp/models.go
@@ -17,6 +17,7 @@ type Tenant struct {
 	Label                string
 	Scopes               []string
 	RequiresBlindedRoute bool
+	SupportsWACI         bool
 }
 
 // UserConnection describes a connection a relying party has with a user.

--- a/pkg/restapi/rp/operation/models.go
+++ b/pkg/restapi/rp/operation/models.go
@@ -27,6 +27,7 @@ type CreateRPTenantRequest struct {
 	Callback             string   `json:"callback"`
 	Scopes               []string `json:"scopes"`
 	RequiresBlindedRoute bool     `json:"requiresBlindedRoute"`
+	SupportsWACI         bool     `json:"supportsWACI"`
 }
 
 // CreateRPTenantResponse API response body to register an RP tenant.
@@ -36,6 +37,7 @@ type CreateRPTenantResponse struct {
 	PublicDID            string   `json:"publicDID"`
 	Scopes               []string `json:"scopes"`
 	RequiresBlindedRoute bool     `json:"requiresBlindedRoute"`
+	SupportsWACI         bool     `json:"supportsWACI"`
 }
 
 // HandleCHAPIResponse is the input message to the chapiResponseHandler handler.

--- a/pkg/restapi/rp/operation/operations.go
+++ b/pkg/restapi/rp/operation/operations.go
@@ -1423,6 +1423,7 @@ func (o *Operation) createRPTenant(w http.ResponseWriter, r *http.Request) {
 		Label:                request.Label,
 		Scopes:               request.Scopes,
 		RequiresBlindedRoute: request.RequiresBlindedRoute,
+		SupportsWACI:         request.SupportsWACI,
 	})
 	if err != nil {
 		msg := fmt.Sprintf("failed to save relying party : %s", err)
@@ -1439,6 +1440,7 @@ func (o *Operation) createRPTenant(w http.ResponseWriter, r *http.Request) {
 		PublicDID:            didID,
 		Scopes:               request.Scopes,
 		RequiresBlindedRoute: request.RequiresBlindedRoute,
+		SupportsWACI:         request.SupportsWACI,
 	})
 }
 

--- a/pkg/restapi/rp/operation/operations_test.go
+++ b/pkg/restapi/rp/operation/operations_test.go
@@ -2798,6 +2798,7 @@ func TestCreateRPTenant(t *testing.T) {
 			Label:                "test label",
 			Scopes:               []string{creditCardStatementScope},
 			RequiresBlindedRoute: true,
+			SupportsWACI:         true,
 		}
 		clientSecret := uuid.New().String()
 
@@ -2838,6 +2839,7 @@ func TestCreateRPTenant(t *testing.T) {
 			Callback:             callback,
 			Scopes:               []string{creditCardStatementScope},
 			RequiresBlindedRoute: true,
+			SupportsWACI:         true,
 		}))
 		require.Equal(t, http.StatusCreated, w.Code)
 		response := &CreateRPTenantResponse{}
@@ -2848,6 +2850,7 @@ func TestCreateRPTenant(t *testing.T) {
 		require.Equal(t, expected.Scopes, response.Scopes)
 		require.Equal(t, clientSecret, response.ClientSecret)
 		require.Equal(t, expected.RequiresBlindedRoute, response.RequiresBlindedRoute)
+		require.Equal(t, expected.SupportsWACI, response.SupportsWACI)
 
 		rpStore, err := rp.New(store)
 		require.NoError(t, err)


### PR DESCRIPTION
This flag will be used to switch between WACI and non-waci (existing) flow.

closes #501 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>